### PR TITLE
Special case certain keyIdentifier values on Linux

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -409,6 +409,11 @@ describe "KeymapManager", ->
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+00dd', ctrl: true))).toBe 'ctrl-]'
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+00de', ctrl: true))).toBe 'ctrl-\''
 
+      it "always includes the shift modifier in the keystroke", ->
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('9', ctrl: true, shift: true))).toBe 'ctrl-shift-9'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('/', ctrl: true, shift: true))).toBe 'ctrl-shift-/'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('a', ctrl: true, shift: true))).toBe 'ctrl-shift-A'
+
   describe "::findKeyBindings({command, target, keystrokes})", ->
     [elementA, elementB] = []
     beforeEach ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -33,7 +33,7 @@ exports.keystrokeForKeyboardEvent = (event) ->
   keystroke.push 'alt' if event.altKey
   if event.shiftKey
     # Don't push 'shift' when modifying symbolic characters like '{'
-    keystroke.push 'shift' unless /^[^A-Za-z]$/.test(key)
+    keystroke.push 'shift' unless /^[^A-Za-z]$/.test(key) and process.platform isnt 'linux'
     # Only upper case alphabetic characters like 'a'
     key = key.toUpperCase() if /^[a-z]$/.test(key)
   else


### PR DESCRIPTION
Came across this bug while digging into some keybinding problems on Linux: https://code.google.com/p/chromium/issues/detail?id=51024
