### PR TITLE
Fix shifted-numbers not turning into appropriate symbols [windows/linux].

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -430,6 +430,18 @@ describe "KeymapManager", ->
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+00bf', ctrl: true, shift: true))).toBe 'ctrl-?'
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('a', ctrl: true, shift: true))).toBe 'ctrl-shift-A'
 
+      it "pressing shift and a number responds with the appropriate symbol", ->
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('1', shift: true))).toBe '!'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('2', shift: true))).toBe '@'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('3', shift: true))).toBe '#'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('4', shift: true))).toBe '$'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('5', shift: true))).toBe '%'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('6', shift: true))).toBe '^'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('7', shift: true))).toBe '&'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('8', shift: true))).toBe '*'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('9', shift: true))).toBe '('
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('0', shift: true))).toBe ')'
+
   describe "::findKeyBindings({command, target, keystrokes})", ->
     [elementA, elementB] = []
     beforeEach ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -86,10 +86,12 @@ exports.normalizeKeystrokes = (keystrokes) ->
 exports.keystrokeForKeyboardEvent = (event) ->
   unless KeyboardEventModifiers.has(event.keyIdentifier)
     keyIdentifierIsHexCharCode = event.keyIdentifier.indexOf('U+') is 0
-    if keyIdentifierIsHexCharCode
+    if isASCII(event.keyCode) and keyIdentifierIsHexCharCode
+      key = keyFromCharCode(event.keyCode, event.shiftKey)
+    else if keyIdentifierIsHexCharCode
       hexCharCode = event.keyIdentifier[2..]
-      charCode = charCodeFromHexCharCode(hexCharCode, event.shiftKey)
-      key = keyFromCharCode(charCode)
+      charCode = charCodeFromHexCharCode(hexCharCode)
+      key = keyFromCharCode(charCode, event.shiftKey)
     else
       key = event.keyIdentifier.toLowerCase()
 
@@ -191,8 +193,10 @@ parseKeystroke = (keystroke) ->
 
   parser.parse(keystroke)
 
-charCodeFromHexCharCode = (hexCharCode, shifted) ->
-  charCode = parseInt(hexCharCode, 16)
+charCodeFromHexCharCode = (hexCharCode) ->
+  parseInt(hexCharCode, 16)
+
+keyFromCharCode = (charCode, shifted) ->
 
   # Chromium includes incorrect keyIdentifier values on keypress events for
   # certain symbols keys on Linux and Windows.
@@ -209,9 +213,6 @@ charCodeFromHexCharCode = (hexCharCode, shifted) ->
       else
         charCode = trans.unshifted
 
-  charCode
-
-keyFromCharCode = (charCode) ->
   switch charCode
     when 8 then 'backspace'
     when 9 then 'tab'


### PR DESCRIPTION
Shifted numbers were not getting translated into the correct symbol.  This PR is to address that. 

Pending comments on #19 as to whether this is an appropriate fix for the issue or not. 
