### PR TITLE
Numpad fix for #25

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -396,6 +396,15 @@ describe "KeymapManager", ->
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('left', shift: true))).toBe 'shift-left'
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('Left', shift: true))).toBe 'shift-left'
 
+    describe "when a numpad key is pressed", ->
+      it "returns a string that identifies the key as the appropriate num-key", ->
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+0041', keyCode: 97, location: 3))).toBe 'num-1'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+0045', keyCode: 101, location: 3))).toBe 'num-5'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+0049', keyCode: 105, location: 3))).toBe 'num-9'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('PageDown', keyCode: 34, location: 3))).toBe 'num-pagedown'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('PageUp', keyCode: 33, location: 3))).toBe 'num-pageup'
+        expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+004B', keyCode: 107, location: 3))).toBe 'num-+'
+
     describe "when a non-English keyboard language is used", ->
       it "uses the physical character pressed instead of the character it maps to in the current language", ->
         expect(keymapManager.keystrokeForKeyboardEvent(keydownEvent('U+03B6', cmd: true, keyCode: 122))).toBe 'cmd-z'

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -104,7 +104,7 @@ exports.keystrokeForKeyboardEvent = (event) ->
   unless KeyboardEventModifiers.has(event.keyIdentifier)
     keyIdentifierIsHexCharCode = event.keyIdentifier.indexOf('U+') is 0
 
-    if event.location is 3
+    if event.location is KeyboardEvent.DOM_KEY_LOCATION_NUMPAD
       # This is a numpad number
       keyCode = numpadToASCII(event.keyCode, event.shiftKey)
     else
@@ -140,7 +140,7 @@ exports.calculateSpecificity = (selector) ->
 exports.isAtomModifier = (key) ->
   AtomModifiers.has(key)
 
-exports.keydownEvent = (key, {ctrl, shift, alt, cmd, which, keyCode, target}={}) ->
+exports.keydownEvent = (key, {ctrl, shift, alt, cmd, which, keyCode, target, location}={}) ->
   event = document.createEvent('KeyboardEvent')
   bubbles = true
   cancelable = true
@@ -166,7 +166,7 @@ exports.keydownEvent = (key, {ctrl, shift, alt, cmd, which, keyCode, target}={})
       else
         keyIdentifier = key[0].toUpperCase() + key[1..]
 
-  location = KeyboardEvent.DOM_KEY_LOCATION_STANDARD
+  location ?= KeyboardEvent.DOM_KEY_LOCATION_STANDARD
   event.initKeyboardEvent('keydown', bubbles, cancelable, view,  keyIdentifier, location, ctrl, alt, shift, cmd)
   Object.defineProperty(event, 'target', get: -> target) if target?
 


### PR DESCRIPTION
This should fix #25.

Right now all the keys on num-pad are preceded by "num-".  I'm not sure if this behavior is desired or not.  Also the delete key isn't working.  Same issue as #27.
