### PR TITLE
WIP: Keybindings can carry detail information now

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt-coffeelint": "^0.0.6",
     "rimraf": "^2.2.2",
     "coffee-cache": "^0.2.0",
-    "temp": "^0.6.0",
+    "temp": "^0.8.0",
     "space-pencil": "^0.3.0",
     "grunt-peg": "^1.2.0"
   }

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 {$$} = require 'space-pencil'
 {appendContent} = require './spec-helper'
 KeymapManager = require '../src/keymap-manager'

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -289,6 +289,7 @@ class KeymapManager
   #     invoked by a KeyboardEvent originating from the target element.
   findKeyBindings: (params={}) ->
     {keystrokes, command, target, keyBindings} = params
+    [command] = command if Array.isArray(command)
 
     bindings = keyBindings ? @keyBindings
 
@@ -426,10 +427,11 @@ class KeymapManager
   # After we match a binding, we call this method to dispatch a custom event
   # based on the binding's command.
   dispatchCommandEvent: (command, target, keyboardEvent) ->
+    [command, data] = command if Array.isArray(command)
     # Here we use prototype chain injection to add CommandEvent methods to this
     # custom event to support aborting key bindings and simulated bubbling for
     # detached targets.
-    commandEvent = new CustomEvent(command, bubbles: true, cancelable: true)
+    commandEvent = new CustomEvent(command, detail: data, bubbles: true, cancelable: true)
     commandEvent.__proto__ = CommandEvent::
     commandEvent.originalEvent = keyboardEvent
 
@@ -497,6 +499,7 @@ class KeymapManager
   # Deprecated: Use {::findKeyBindings} with the 'command' param.
   keyBindingsForCommand: (command) ->
     Grim.deprecate("Use KeymapManager::findKeyBindings instead.")
+    [command] = command if Array.isArray(command)
     @findKeyBindings({command})
 
   # Deprecated: Use {::findKeyBindings} with the 'keystrokes' param.
@@ -513,6 +516,7 @@ class KeymapManager
   # params
   keyBindingsForCommandMatchingElement: (command, target) ->
     Grim.deprecate("Use KeymapManager::findKeyBindings instead.")
+    [command] = command if Array.isArray(command)
     @findKeyBindings({command, target: target[0] ? target})
 
   # Deprecated: Use {::findKeyBindings} with the 'keystrokes' and 'target'


### PR DESCRIPTION
Now, this is only a *proof-of-concept* right now, but better then nothing right?

I missed the possibility to transport information in my keybindings. We could use this to insert commonly used snippets for example. I looked into the `atom-keymap` and out came this.

Imagine keybindings like this (the old ones still work perfectly fine):
```coffee
'.workspace .editor:not(.mini)':
  'alt-enter': ['editor:insert-custom-snippet', 'legal']
```

What it is supposed to do is invoke `editor:insert-custom-snippet` and pass `legal` as detail. The corresponding function looks like this right now (it's ugly code but you can see what it does):

```coffee
atom.workspaceView.command 'editor:insert-custom-snippet', ({originalEvent}) ->
  detail = originalEvent.detail
  snippets = atom.packages.activePackages.snippets.mainModule.getSnippets(atom.workspace.getActiveEditor())
  atom.packages.activePackages.snippets?.mainModule?.insert snippets[detail]
```

All specs are still passing and the only "bugs" I found so far are:
* To access the detail we have to access `(e) -> e.originalEvent.detail`. Not sure how to set the `detail` directly onto the "main" event.
* Keybinding resolver won't display the target (`editor:insert-custom-snippet`).

What do you think?

*Note: I updated `temp` to make the specs work on linux.*