### PR TITLE
:apple: Show the unicode for unrecognised keys

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -120,6 +120,10 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
     else
       key = event.keyIdentifier.toLowerCase()
 
+    if key is 'unidentified'
+      hexCode = "0000#{event.keyCode.toString(16)}"[-4..]
+      key = "U+#{hexCode}"
+
   keystroke = ''
   if event.ctrlKey
     keystroke += 'ctrl'


### PR DESCRIPTION
This is saving my day in my apple keyboard with a Spanish ISO layout

The problem is with characters waiting for a second character to be
composed. For example the accents, when you press the ` key the OS
waits for a second keypress to compose the char à for example.

But we are using keydown events, so the key will not be identified as `
because is not a full character yet.

With other chars like ] which is printed after pressing right_alt-+ the
keydown event detects alt-+ because the ] char is on the + key
accesible as 3rd option (the right_alt key works as an alternative
shift key).