### PR TITLE
Fixes wrong keyIdentifiers of modifiers in the Linux and Windows Chromium versions

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -494,6 +494,14 @@ describe "KeymapManager", ->
           expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00dd', ctrl: true, shift: true))).toBe 'ctrl-}'
           expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00de', ctrl: true, shift: true))).toBe 'ctrl-"'
 
+          # Single modifiers
+          expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00A0', shift: true))).toBe 'shift'
+          expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00A1', shift: true))).toBe 'shift'
+          expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00A2', ctrl: true))).toBe 'ctrl'
+          expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00A3', ctrl: true))).toBe 'ctrl'
+          expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00A4', alt: true))).toBe 'alt'
+          expect(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent('U+00A5', alt: true))).toBe 'alt'
+
         Object.defineProperty process, 'platform', value: 'win32'
         testTranslations()
         Object.defineProperty process, 'platform', value: 'linux'


### PR DESCRIPTION
I added translations for wrong keyIdentifiers of modifiers in the Linux and Windows Chromium versions.
I verified the keyIdentifiers in Chrome on Linux using:
```javascript
document.addEventListener('keydown', function (e) { console.log(e) });
```
This fixes #65.

I also refactored the preprocessing done in keystrokeForKeyboardEvent so it should be easier to handle bugs like this now.