### PR TITLE
Speed up normalizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib/
 atom
 .coffee/
 api.json
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ npm-debug.log
 .travis.yml
 .pairs
 .coffee
+benchmark

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -38,13 +38,7 @@ module.exports = (grunt) ->
           stderr: true
           failOnError: true
 
-    peg:
-      keystroke:
-        src: 'src/keystroke.pegjs'
-        dest: 'lib/keystroke.js'
-
   grunt.loadNpmTasks('grunt-contrib-coffee')
-  grunt.loadNpmTasks('grunt-peg')
   grunt.loadNpmTasks('grunt-shell')
   grunt.loadNpmTasks('grunt-coffeelint')
   grunt.loadNpmTasks('grunt-atomdoc')
@@ -54,6 +48,6 @@ module.exports = (grunt) ->
     require('rimraf').sync('api.json')
 
   grunt.registerTask('lint', ['coffeelint'])
-  grunt.registerTask('default', ['lint', 'coffee', 'peg'])
+  grunt.registerTask('default', ['lint', 'coffee'])
   grunt.registerTask('test', ['coffee', 'lint', 'shell:test'])
-  grunt.registerTask('prepublish', ['clean', 'lint', 'coffee', 'peg', 'shell:update-atomdoc', 'atomdoc'])
+  grunt.registerTask('prepublish', ['clean', 'lint', 'coffee', 'shell:update-atomdoc', 'atomdoc'])

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -1,30 +1,35 @@
 helpers = require '../src/helpers'
 
 start = Date.now()
+count = 0
 
-for letter in 'abcdefghijklmnopqrztuvwxyz'
-  helpers.normalizeKeystrokes(letter)
-  helpers.normalizeKeystrokes("shift-#{letter}")
+normalize = (keystrokes) ->
+  count++
+  helpers.normalizeKeystrokes(keystrokes)
 
-  helpers.normalizeKeystrokes("cmd-#{letter}")
-  helpers.normalizeKeystrokes("cmd-shift-#{letter}")
-  helpers.normalizeKeystrokes("cmd-alt-#{letter}")
-  helpers.normalizeKeystrokes("cmd-alt-ctrl-#{letter}")
-  helpers.normalizeKeystrokes("cmd-alt-ctrl-shfit-#{letter}")
-  helpers.normalizeKeystrokes("cmd-#{letter} cmd-v")
+for letter in 'abcdefghijklmnopqrztuvwxyz0123456789'
+  normalize(letter)
+  normalize("shift-#{letter}")
 
-  helpers.normalizeKeystrokes("alt-#{letter}")
-  helpers.normalizeKeystrokes("alt-shift-#{letter}")
-  helpers.normalizeKeystrokes("alt-cmd-#{letter}")
-  helpers.normalizeKeystrokes("alt-cmd-ctrl-#{letter}")
-  helpers.normalizeKeystrokes("alt-cmd-ctrl-shift-#{letter}")
-  helpers.normalizeKeystrokes("alt-#{letter} alt-v")
+  normalize("cmd-#{letter}")
+  normalize("cmd-shift-#{letter}")
+  normalize("cmd-alt-#{letter}")
+  normalize("cmd-alt-ctrl-#{letter}")
+  normalize("cmd-alt-ctrl-shfit-#{letter}")
+  normalize("cmd-#{letter} cmd-v")
 
-  helpers.normalizeKeystrokes("ctrl-#{letter}")
-  helpers.normalizeKeystrokes("ctrl-shift-#{letter}")
-  helpers.normalizeKeystrokes("ctrl-alt-#{letter}")
-  helpers.normalizeKeystrokes("ctrl-alt-cmd-#{letter}")
-  helpers.normalizeKeystrokes("ctrl-alt-cmd-shift#{letter}")
-  helpers.normalizeKeystrokes("ctrl-#{letter} ctrl-v")
+  normalize("alt-#{letter}")
+  normalize("alt-shift-#{letter}")
+  normalize("alt-cmd-#{letter}")
+  normalize("alt-cmd-ctrl-#{letter}")
+  normalize("alt-cmd-ctrl-shift-#{letter}")
+  normalize("alt-#{letter} alt-v")
 
-console.log Date.now() - start
+  normalize("ctrl-#{letter}")
+  normalize("ctrl-shift-#{letter}")
+  normalize("ctrl-alt-#{letter}")
+  normalize("ctrl-alt-cmd-#{letter}")
+  normalize("ctrl-alt-cmd-shift#{letter}")
+  normalize("ctrl-#{letter} ctrl-v")
+
+console.log "Normalized #{count} keystrokes in #{Date.now() - start}ms"

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -1,11 +1,12 @@
 helpers = require '../src/helpers'
 
-start = Date.now()
 count = 0
 
 normalize = (keystrokes) ->
   count++
   helpers.normalizeKeystrokes(keystrokes)
+
+start = Date.now()
 
 for letter in 'abcdefghijklmnopqrztuvwxyz0123456789'
   normalize(letter)

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -1,0 +1,30 @@
+helpers = require '../src/helpers'
+
+start = Date.now()
+
+for letter in 'abcdefghijklmnopqrztuvwxyz'
+  helpers.normalizeKeystrokes(letter)
+  helpers.normalizeKeystrokes("shift-#{letter}")
+
+  helpers.normalizeKeystrokes("cmd-#{letter}")
+  helpers.normalizeKeystrokes("cmd-shift-#{letter}")
+  helpers.normalizeKeystrokes("cmd-alt-#{letter}")
+  helpers.normalizeKeystrokes("cmd-alt-ctrl-#{letter}")
+  helpers.normalizeKeystrokes("cmd-alt-ctrl-shfit-#{letter}")
+  helpers.normalizeKeystrokes("cmd-#{letter} cmd-v")
+
+  helpers.normalizeKeystrokes("alt-#{letter}")
+  helpers.normalizeKeystrokes("alt-shift-#{letter}")
+  helpers.normalizeKeystrokes("alt-cmd-#{letter}")
+  helpers.normalizeKeystrokes("alt-cmd-ctrl-#{letter}")
+  helpers.normalizeKeystrokes("alt-cmd-ctrl-shift-#{letter}")
+  helpers.normalizeKeystrokes("alt-#{letter} alt-v")
+
+  helpers.normalizeKeystrokes("ctrl-#{letter}")
+  helpers.normalizeKeystrokes("ctrl-shift-#{letter}")
+  helpers.normalizeKeystrokes("ctrl-alt-#{letter}")
+  helpers.normalizeKeystrokes("ctrl-alt-cmd-#{letter}")
+  helpers.normalizeKeystrokes("ctrl-alt-cmd-shift#{letter}")
+  helpers.normalizeKeystrokes("ctrl-#{letter} ctrl-v")
+
+console.log Date.now() - start

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./lib/keymap-manager",
   "scripts": {
     "prepublish": "grunt prepublish",
-    "test": "grunt test"
+    "test": "grunt test",
+    "benchmark": "coffee --nodejs --harmony_collections benchmark/benchmark.coffee"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "keyboard-layout": "^0.10.0",
     "loophole": "^1.0.0",
     "pathwatcher": "^4.2",
-    "pegjs": "^0.8.0",
     "property-accessors": "^1",
     "season": "^5.0.2",
     "underscore-plus": "^1.0.0"
@@ -46,7 +45,6 @@
     "coffee-cache": "^0.2.0",
     "temp": "^0.6.0",
     "space-pencil": "^0.3.0",
-    "grunt-peg": "^1.2.0",
     "grunt-atomdoc": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "fs-plus": "^2.0.4",
     "grim": "^1.0.0",
     "keyboard-layout": "^0.10.0",
-    "loophole": "^1.0.0",
     "pathwatcher": "^4.2",
     "property-accessors": "^1",
     "season": "^5.0.2",

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -19,9 +19,8 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('a-b')).toBe false
     expect(normalizeKeystrokes('---')).toBe false
     expect(normalizeKeystrokes('cmd-a-b')).toBe false
-
-    expect(-> normalizeKeystrokes('-a-b')).toThrow()
-    expect(-> normalizeKeystrokes('ctrl-')).toThrow()
-    expect(-> normalizeKeystrokes('--')).toThrow()
-    expect(-> normalizeKeystrokes('- ')).toThrow()
-    expect(-> normalizeKeystrokes('a ')).toThrow()
+    expect(normalizeKeystrokes('-a-b')).toBe false
+    expect(normalizeKeystrokes('ctrl-')).toBe false
+    expect(normalizeKeystrokes('--')).toBe false
+    expect(normalizeKeystrokes('- ')).toBe false
+    expect(normalizeKeystrokes('a ')).toBe false

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,5 +1,5 @@
 {specificity} = require 'clear-cut'
-[parser, fs, loophole, pegjs] = []
+[fs, loophole, pegjs] = []
 
 AtomModifiers = new Set
 AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'shift', 'cmd']
@@ -228,17 +228,14 @@ normalizeKeystroke = (keystroke) ->
   keystroke.join('-')
 
 parseKeystroke = (keystroke) ->
-  unless parser?
-    try
-      parser = require './keystroke'
-    catch e
-      fs ?= require 'fs'
-      loophole ?= require 'loophole'
-      pegjs ?= require 'pegjs'
-      keystrokeGrammar = fs.readFileSync(require.resolve('./keystroke.pegjs'), 'utf8')
-      loophole.allowUnsafeEval => parser = pegjs.buildParser(keystrokeGrammar)
-
-  parser.parse(keystroke)
+  keys = []
+  keyStart = 0
+  for character, index in keystroke when character is '-'
+    if index > keyStart
+      keys.push(keystroke.substring(keyStart, index))
+      keyStart = index + 1
+  keys.push(keystroke.substring(keyStart)) if keyStart < keystroke.length
+  keys
 
 charCodeFromKeyIdentifier = (keyIdentifier) ->
   parseInt(keyIdentifier[2..], 16) if keyIdentifier.indexOf('U+') is 0

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -116,7 +116,7 @@ exports.normalizeKeystrokes = (keystrokes) ->
 
 exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
   keyIdentifier = event.keyIdentifier
-  if process.platform is 'linux' or process.platform is 'win32'
+  if process.platform in ['linux', 'win32']
     keyIdentifier = translateKeyIdentifierForWindowsAndLinuxChromiumBug(keyIdentifier)
 
   unless KeyboardEventModifiers.has(keyIdentifier)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -5,6 +5,7 @@ AtomModifiers = new Set
 AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'shift', 'cmd']
 
 AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
+WhitespaceRegex = /\s+/
 
 KeyboardEventModifiers = new Set
 KeyboardEventModifiers.add(modifier) for modifier in ['Control', 'Alt', 'Shift', 'Meta']
@@ -104,7 +105,7 @@ NumPadToASCII =
 
 exports.normalizeKeystrokes = (keystrokes) ->
   normalizedKeystrokes = []
-  for keystroke in keystrokes.split(/\s+/)
+  for keystroke in keystrokes.split(WhitespaceRegex)
     if normalizedKeystroke = normalizeKeystroke(keystroke)
       normalizedKeystrokes.push(normalizedKeystroke)
     else

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -127,7 +127,7 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
         charCode = event.keyCode
 
     if charCode?
-      if process.platform is 'linux' or process.platform is 'win32'
+      if process.platform in ['linux', 'win32']
         charCode = translateCharCodeForWindowsAndLinuxChromiumBug(charCode, event.shiftKey)
 
       if event.location is KeyboardEvent.DOM_KEY_LOCATION_NUMPAD

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -205,6 +205,8 @@ exports.keydownEvent = (key, {ctrl, shift, alt, cmd, keyCode, target, location}=
 
 normalizeKeystroke = (keystroke) ->
   keys = parseKeystroke(keystroke)
+  return false unless keys
+
   primaryKey = null
   modifiers = new Set
 
@@ -237,6 +239,9 @@ parseKeystroke = (keystroke) ->
     if index > keyStart
       keys.push(keystroke.substring(keyStart, index))
       keyStart = index + 1
+
+      # The keystroke has a trailing - and is invalid
+      return false if keyStart is keystroke.length
   keys.push(keystroke.substring(keyStart)) if keyStart < keystroke.length
   keys
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,5 +1,4 @@
 {specificity} = require 'clear-cut'
-[fs, loophole, pegjs] = []
 
 AtomModifiers = new Set
 AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'shift', 'cmd']

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -6,6 +6,8 @@ AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'shift', 'cmd']
 
 AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
 WhitespaceRegex = /\s+/
+LowerCaseLetterRegex = /^[a-z]$/
+UpperCaseLetterRegex = /^[A-Z]$/
 
 KeyboardEventModifiers = new Set
 KeyboardEventModifiers.add(modifier) for modifier in ['Control', 'Alt', 'Shift', 'Meta']
@@ -151,9 +153,9 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
       keystroke += '-' if keystroke
       keystroke += 'shift'
     # Only upper case alphabetic characters like 'a'
-    key = key.toUpperCase() if /^[a-z]$/.test(key)
+    key = key.toUpperCase() if LowerCaseLetterRegex.test(key)
   else
-    key = key.toLowerCase() if /^[A-Z]$/.test(key)
+    key = key.toLowerCase() if UpperCaseLetterRegex.test(key)
   if event.metaKey
     keystroke += '-' if keystroke
     keystroke += 'cmd'
@@ -175,7 +177,7 @@ exports.keydownEvent = (key, {ctrl, shift, alt, cmd, keyCode, target, location}=
   cancelable = true
   view = null
 
-  key = key.toUpperCase() if /^[a-z]$/.test(key)
+  key = key.toUpperCase() if LowerCaseLetterRegex.test(key)
   if key.length is 1
     keyIdentifier = "U+#{key.charCodeAt(0).toString(16)}"
   else
@@ -217,8 +219,9 @@ normalizeKeystroke = (keystroke) ->
       else
         return false
 
-  modifiers.add('shift') if /^[A-Z]$/.test(primaryKey)
-  primaryKey = primaryKey.toUpperCase() if modifiers.has('shift') and /^[a-z]$/.test(primaryKey)
+  modifiers.add('shift') if UpperCaseLetterRegex.test(primaryKey)
+  if modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
+    primaryKey = primaryKey.toUpperCase()
 
   keystroke = []
   keystroke.push('ctrl') if modifiers.has('ctrl')

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -120,12 +120,14 @@ class KeymapManager
     @queuedKeystrokes = []
     @watchSubscriptions = {}
     @enableDvorakQwertyWorkaroundIfNeeded()
+    @testSelectorElement = document.createElement('div')
 
   # Public: Unwatch all watched paths.
   destroy: ->
     @keyboardLayoutSubscription.dispose()
     for filePath, subscription of @watchSubscriptions
       subscription.dispose()
+    @testSelectorElement = null
     undefined
 
   enableDvorakQwertyWorkaroundIfNeeded: ->
@@ -242,9 +244,7 @@ class KeymapManager
     addedKeyBindings = []
     for selector, keyBindings of keyBindingsBySelector
       # Verify selector is valid before registering any bindings
-      try
-        document.body.webkitMatchesSelector(selector.replace(/!important/g, ''))
-      catch e
+      unless @isValidSelector(selector.replace(/!important/g, ''))
         console.warn("Encountered an invalid selector adding key bindings from '#{source}': '#{selector}'")
         return
 
@@ -609,6 +609,13 @@ class KeymapManager
     {keyBindingAborted} = commandEvent
     keyboardEvent.preventDefault() unless keyBindingAborted
     not keyBindingAborted
+
+  isValidSelector: (selector) ->
+    try
+      @testSelectorElement.querySelector(selector)
+      true
+    catch error
+      false
 
   # Chromium does not bubble events dispatched on detached targets, which makes
   # testing a pain in the ass. This method simulates bubbling manually.

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -120,15 +120,20 @@ class KeymapManager
     @queuedKeystrokes = []
     @watchSubscriptions = {}
     @enableDvorakQwertyWorkaroundIfNeeded()
+
     @testSelectorElement = document.createElement('div')
+    @selectorCache = {}
 
   # Public: Unwatch all watched paths.
   destroy: ->
     @keyboardLayoutSubscription.dispose()
     for filePath, subscription of @watchSubscriptions
       subscription.dispose()
+
     @testSelectorElement = null
-    undefined
+    @selectorCache = null
+
+    return
 
   enableDvorakQwertyWorkaroundIfNeeded: ->
     @keyboardLayoutSubscription = observeCurrentKeyboardLayout (layoutId) =>
@@ -613,10 +618,15 @@ class KeymapManager
     not keyBindingAborted
 
   isValidSelector: (selector) ->
+    cachedValue = @selectorCache[selector]
+    return cachedValue if cachedValue?
+
     try
       @testSelectorElement.querySelector(selector)
+      @selectorCache[selector] = true
       true
     catch error
+      @selectorCache[selector] = false
       false
 
   # Chromium does not bubble events dispatched on detached targets, which makes

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -260,6 +260,7 @@ class KeymapManager
       for keyBinding in addedKeyBindings
         index = @keyBindings.indexOf(keyBinding)
         @keyBindings.splice(index, 1) unless index is -1
+      return
 
   remove: (source) ->
     Grim.deprecate("Call .dispose() on the Disposable returned from KeymapManager::add instead")
@@ -590,6 +591,7 @@ class KeymapManager
     binding.enabled = false for binding in bindingsToDisable
     @handleKeyboardEvent(event, true) for event in eventsToReplay
     binding.enabled = true for binding in bindingsToDisable
+    return
 
   # After we match a binding, we call this method to dispatch a custom event
   # based on the binding's command.
@@ -628,6 +630,7 @@ class KeymapManager
       break if commandEvent.propagationStopped
       break if currentTarget is window
       currentTarget = currentTarget.parentNode ? window
+    return
 
   # Deprecated: Use {::add} instead.
   addKeymap: (source, bindings) ->

--- a/src/keystroke.pegjs
+++ b/src/keystroke.pegjs
@@ -1,3 +1,0 @@
-keystrokePattern = key:key additionalKeys:additionalKey* { return [key].concat(additionalKeys); }
-additionalKey = '-' key:key { return key; }
-key = '-' / chars:[^-]+ { return chars.join('') }


### PR DESCRIPTION
This drops time spent in `KeymapManager::add` from `~30ms` to `~15ms` for the keymaps loaded by the core keymaps loaded by Atom.

- [x] Parse keystrokes directly instead of using a pegjs grammar (the generated js for the peg was 300 lines)
- [x] Use a faster selector validation approach