### PR TITLE
Always reload keymap if CSON parsing succeeded

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -595,6 +595,31 @@ describe "KeymapManager", ->
               expect(keymapManager.findKeyBindings(command: 'y').length).toBe 1
               expect(keymapManager.findKeyBindings(command: 'z').length).toBe 1
 
+          it "reloads the file's key bindings and notifies ::onDidReloadKeymap observers with the keymap path even if the file is empty", ->
+            fs.writeFileSync keymapFilePath, ""
+
+            waitsFor 300, (done) ->
+              keymapManager.onDidReloadKeymap (event) ->
+                expect(event.path).toBe keymapFilePath
+                done()
+
+            runs ->
+              expect(keymapManager.getKeyBindings().length).toBe 0
+
+          it "reloads the file's key bindings and notifies ::onDidReloadKeymap observers with the keymap path even if the file has only comments", ->
+            fs.writeFileSync keymapFilePath, """
+            #  '.a': 'ctrl-a': 'y'
+            #  '.b': 'ctrl-b': 'z'
+            """
+
+            waitsFor 300, (done) ->
+              keymapManager.onDidReloadKeymap (event) ->
+                expect(event.path).toBe keymapFilePath
+                done()
+
+            runs ->
+              expect(keymapManager.getKeyBindings().length).toBe 0
+
           it "emits an event, logs a warning and does not reload if there is a problem reloading the file", ->
             didFailSpy = jasmine.createSpy()
             keymapManager.onDidFailToReadFile(didFailSpy)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -334,7 +334,9 @@ class KeymapManager
   # we can't read the file cleanly, we don't proceed with the reload.
   reloadKeymap: (filePath) ->
     if fs.isFileSync(filePath)
-      if bindings = @readKeymap(filePath, true)
+      bindings = @readKeymap(filePath, true)
+
+      if typeof bindings isnt "undefined"
         @removeBindingsFromSource(filePath)
         @add(filePath, bindings)
         @emit 'reloaded-key-bindings', filePath if Grim.includeDeprecatedAPIs


### PR DESCRIPTION
This fixes https://github.com/atom/atom-keymap/issues/69.

It seems that [this check](https://github.com/atom/atom-keymap/blob/ad7566febcc835318f46fa554863b4797865f1bb/src/keymap-manager.coffee#L337):

```
if bindings = @readKeymap(filePath, true)
  # code for reloading the keymap
```

is currently failing for two different situations, so reloading doesn't happen:
* `readKeymap` returned `undefined`, which happens when CSON parsing failed. It's expected that reloading doesn't happen in this situation, so the check is fine for this.
* `readKeymap` returned `null`, which happens when CSON parsing succeeded, but the CSON file was either empty or had only comments (i.e. no CSON objects were parsed). It's expected that reloading does happen in this situation, so the check needs to be fixed for this.

This pull request tweaks the check so that the keymap is reloaded even if no CSON objects were found after successful parsing. In other words, if CSON parsing was okay, the keymap is reloaded.

1bad0d3 adds specs which expectedly fail with this output without the fix applied:

```
.......................................FF........

KeymapManager
  ::loadKeymap(path, options)
    if called with a file path
      if called with watch: true
        when the file is changed
          it reloads the file's key bindings and notifies ::onDidReloadKeymap observers with the keymap path if the file is empty or has only comments
            timeout: timed out after 300 msec waiting for something to happen
          it reloads the file's key bindings and notifies ::onDidReloadKeymap observers with the keymap path if the file has only comments
            timeout: timed out after 300 msec waiting for something to happen


Finished in 2.817 seconds
49 tests, 258 assertions, 2 failures, 0 skipped
```

cc @kevinsawicki @nathansobo for :eyes: 