### PR TITLE
WIP: Tries to address the altgr modifier handling (windows and linux)

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,15 +1,15 @@
 {calculateSpecificity} = require 'clear-cut'
 
 AtomModifiers = new Set
-AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'shift', 'cmd']
+AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'altgr', 'shift', 'cmd']
 
-AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
+AtomModifierRegex = /(ctrl|alt|altgr|shift|cmd)$/
 WhitespaceRegex = /\s+/
 LowerCaseLetterRegex = /^[a-z]$/
 UpperCaseLetterRegex = /^[A-Z]$/
 
 KeyboardEventModifiers = new Set
-KeyboardEventModifiers.add(modifier) for modifier in ['Control', 'Alt', 'Shift', 'Meta']
+KeyboardEventModifiers.add(modifier) for modifier in ['Control', 'Alt', 'AltGr', 'Shift', 'Meta']
 
 WindowsAndLinuxKeyIdentifierTranslations =
   'U+00A0': 'Shift'
@@ -138,12 +138,18 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
     else
       key = keyIdentifier.toLowerCase()
 
+  # get modifier state from ModifierStateHandler instead of keyevent
+  modifierState = atom.keymaps.modifierStateHandler.getState()
+
   keystroke = ''
-  if event.ctrlKey
+  if modifierState.ctrl
     keystroke += 'ctrl'
-  if event.altKey
+  if modifierState.alt
     keystroke += '-' if keystroke
     keystroke += 'alt'
+  if modifierState.altgr
+    keystroke += '-' if keystroke
+    keystroke += 'altgr'
   if event.shiftKey
     # Don't push 'shift' when modifying symbolic characters like '{'
     unless /^[^A-Za-z]$/.test(key)
@@ -224,6 +230,7 @@ normalizeKeystroke = (keystroke) ->
   keystroke = []
   keystroke.push('ctrl') if modifiers.has('ctrl')
   keystroke.push('alt') if modifiers.has('alt')
+  keystroke.push('altgr') if modifiers.has('altgr')
   keystroke.push('shift') if modifiers.has('shift')
   keystroke.push('cmd') if modifiers.has('cmd')
   keystroke.push(primaryKey) if primaryKey?

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,4 +1,7 @@
 {calculateSpecificity} = require 'clear-cut'
+ModifierStateHandler = require './modifier-state-handler'
+
+modifierStateHandler = new ModifierStateHandler
 
 AtomModifiers = new Set
 AtomModifiers.add(modifier) for modifier in ['ctrl', 'alt', 'altgr', 'shift', 'cmd']
@@ -112,6 +115,7 @@ exports.normalizeKeystrokes = (keystrokes) ->
   normalizedKeystrokes.join(' ')
 
 exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
+  modifierStateHandler.handleKeyEvent(event)
   keyIdentifier = event.keyIdentifier
   if process.platform in ['linux', 'win32']
     keyIdentifier = translateKeyIdentifierForWindowsAndLinuxChromiumBug(keyIdentifier)
@@ -139,7 +143,7 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
       key = keyIdentifier.toLowerCase()
 
   # get modifier state from ModifierStateHandler instead of keyevent
-  modifierState = atom.keymaps.modifierStateHandler.getState()
+  modifierState = modifierStateHandler.getState()
 
   keystroke = ''
   if modifierState.ctrl

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -8,7 +8,6 @@ path = require 'path'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
 KeyBinding = require './key-binding'
 CommandEvent = require './command-event'
-ModifierStateHandler = require './modifier-state-handler'
 {normalizeKeystrokes, keystrokeForKeyboardEvent, isAtomModifier, keydownEvent} = require './helpers'
 
 Platforms = ['darwin', 'freebsd', 'linux', 'sunos', 'win32']
@@ -109,7 +108,6 @@ class KeymapManager
   constructor: (options={}) ->
     @[key] = value for key, value of options
     @emitter = new Emitter
-    @modifierStateHandler = new ModifierStateHandler
     @keyBindings = []
     @queuedKeyboardEvents = []
     @queuedKeystrokes = []
@@ -395,7 +393,6 @@ class KeymapManager
   #
   # * `event` A `KeyboardEvent` of type 'keydown'
   handleKeyboardEvent: (event, replaying) ->
-    @modifierStateHandler.handleKeyEvent(event)
     keystroke = @keystrokeForKeyboardEvent(event)
 
     if @queuedKeystrokes.length > 0 and isAtomModifier(keystroke)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -8,6 +8,7 @@ path = require 'path'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
 KeyBinding = require './key-binding'
 CommandEvent = require './command-event'
+ModifierStateHandler = require './modifier-state-handler'
 {normalizeKeystrokes, keystrokeForKeyboardEvent, isAtomModifier, keydownEvent} = require './helpers'
 
 Platforms = ['darwin', 'freebsd', 'linux', 'sunos', 'win32']
@@ -108,6 +109,7 @@ class KeymapManager
   constructor: (options={}) ->
     @[key] = value for key, value of options
     @emitter = new Emitter
+    @modifierStateHandler = new ModifierStateHandler
     @keyBindings = []
     @queuedKeyboardEvents = []
     @queuedKeystrokes = []
@@ -393,6 +395,7 @@ class KeymapManager
   #
   # * `event` A `KeyboardEvent` of type 'keydown'
   handleKeyboardEvent: (event, replaying) ->
+    @modifierStateHandler.handleKeyEvent(event)
     keystroke = @keystrokeForKeyboardEvent(event)
 
     if @queuedKeystrokes.length > 0 and isAtomModifier(keystroke)

--- a/src/modifier-state-handler.coffee
+++ b/src/modifier-state-handler.coffee
@@ -1,0 +1,179 @@
+###
+AlgGr-Modifier detection
+Some code parts are from here:
+https://github.com/adobe/brackets/blob/master/src/command/KeyBindingManager.js
+###
+
+module.exports =
+class ModifierStateHandler
+  # States of Ctrl key down detection
+  # @enum {number}
+  CtrlDownStates:
+    NOT_YET_DETECTED: 0
+    DETECTED: 1
+    DETECTED_AND_IGNORED: 2
+
+  # Flags used to determine whether right Alt key is pressed. When it is pressed,
+  # the following two keydown events are triggered in that specific order.
+  #
+  #    1. ctrlDown - flag used to record { ctrlKey: true, keyIdentifier: "Control", ... } keydown event
+  #    2. altGrDown - flag used to record { ctrlKey: true, altKey: true, keyIdentifier: "Alt", ... } keydown event
+  #
+  # @type {CtrlDownStates}
+  ctrlDown: 0 # initialize with CtrlDownState => NOT_YET_DETECTED
+  altGrDown: false
+
+  hasCtrl: false
+  hasAltGr: false
+  hasAlt: false
+
+  # Constant used for checking the interval between Control keydown event and Alt keydown event.
+  # If the right Alt key is down we get Control keydown followed by Alt keydown within 30 ms. if
+  # the user is pressing Control key and then Alt key, the interval will be larger than 30 ms.
+  # @type {number}
+  MAX_INTERVAL_FOR_CTRL_ALT_KEYS: 30
+
+  # Constant used for identifying AltGr on Linux
+  # @type {String}
+  LINUX_ALTGR_IDENTIFIER = 'U+00E1'
+
+  # Used to record the timeStamp property of the last keydown event.
+  # @type {number}
+  lastTimeStamp: null
+
+  # Used to record the keyIdentifier property of the last keydown event.
+  # @type {string}
+  lastKeyIdentifier: null
+
+  # keyUpListener for AltGrMode
+  # @type {event}
+  keyUpEventListener: null
+
+  # clear modifier listener on editor blur
+  # @type {event}
+  clearModifierStateListener: =>
+    @clearModifierState()
+
+  constructor: ->
+    # clear listener on editor blur
+    window.addEventListener 'blur', @clearModifierStateListener
+
+  destroy: ->
+    # remove listener
+    window.removeEventListener 'blur', @clearModifierStateListener
+
+  clearModifierState: ->
+    if process.platform = 'win32'
+      @quitAltGrMode()
+    @hasCtrl = false
+    @hasAltGr = false
+    @hasAlt = false
+
+  # Resets all the flags and removes onAltGrUp event listener.
+  quitAltGrMode: ->
+    @ctrlDown = @CtrlDownStates.NOT_YET_DETECTED
+    @altGrDown = false
+    @hasAltGr = false
+    @lastTimeStamp = null
+    @lastKeyIdentifier = null
+    document.removeEventListener 'keyup', @keyUpEventListener
+
+  # Detects the release of AltGr key by checking all keyup events
+  # until we receive one with ctrl key code. Once detected, reset
+  # all the flags and also remove this event listener.
+  #
+  # @param {!KeyboardEvent} e keyboard event object
+  onAltGrUp: (e) ->
+    if process.platform = 'win32'
+      key = e.keyCode || e.which
+      if @altGrDown && key == 17 # 17 = KeyEvent.DOM_VK_CONTROL
+        @quitAltGrMode()
+    if process.platform = 'linux'
+      if e.keyIdentifier == LINUX_ALTGR_IDENTIFIER
+        @quitAltGrMode()
+
+  # Detects whether AltGr key is pressed. When it is pressed, the first keydown event has
+  # ctrlKey === true with keyIdentifier === "Control". The next keydown event with
+  # altKey === true, ctrlKey === true and keyIdentifier === "Alt" is sent within 30 ms. Then
+  # the next keydown event with altKey === true, ctrlKey === true and keyIdentifier === "Control"
+  # is sent. If the user keep holding AltGr key down, then the second and third
+  # keydown events are repeatedly sent out alternately. If the user is also holding down Ctrl
+  # key, then either keyIdentifier === "Control" or keyIdentifier === "Alt" is repeatedly sent
+  # but not alternately.
+  #
+  # @param {!KeyboardEvent} e keyboard event object
+  detectAltGrKeyDown: (e) ->
+    if process.platform = 'win32'
+      if !@altGrDown
+        if @ctrlDown != @CtrlDownStates.DETECTED_AND_IGNORED && e.ctrlKey && e.keyIdentifier == 'Control'
+          @ctrlDown = @CtrlDownStates.DETECTED
+        else if e.repeat && e.ctrlKey && e.keyIdentifier == 'Control'
+          # We get here if the user is holding down left/right Control key. Set it to false
+          # so that we don't misidentify the combination of Ctrl and Alt keys as AltGr key.
+          @ctrlDown = @CtrlDownStates.DETECTED_AND_IGNORED
+        else if @ctrlDown == @CtrlDownStates.DETECTED && e.altKey && e.ctrlKey && e.keyIdentifier == 'Alt' && e.timeStamp - @lastTimeStamp < @MAX_INTERVAL_FOR_CTRL_ALT_KEYS && e.keyLocation == 2
+          @altGrDown = true
+          @lastKeyIdentifier = 'Alt'
+          @keyUpEventListener = (e) =>
+            @onAltGrUp(e)
+          document.addEventListener 'keyup', @keyUpEventListener
+        else
+          # Reset ctrlDown so that we can start over in detecting the two key events
+          # required for AltGr key.
+          @ctrlDown = @CtrlDownStates.NOT_YET_DETECTED
+        @lastTimeStamp = e.timeStamp
+      else if e.keyIdentifier == 'Control' || e.keyIdentifier == 'Alt'
+        # If the user is NOT holding down AltGr key or is also pressing Ctrl key,
+        # then lastKeyIdentifier will be the same as keyIdentifier in the current
+        # key event. So we need to quit AltGr mode.
+        if e.altKey && e.ctrlKey && e.keyIdentifier == @lastKeyIdentifier
+          @quitAltGrMode()
+        else
+          @lastKeyIdentifier = e.keyIdentifier
+    if process.platform = 'linux'
+      if !@altGrDown
+        if e.keyIdentifier == LINUX_ALTGR_IDENTIFIER
+          @altGrDown = true
+          @keyUpEventListener = (e) =>
+            @onAltGrUp(e)
+          document.addEventListener 'keyup', @keyUpEventListener
+    else
+      return
+
+  # Handle key event
+  #
+  # @param {!KeyboardEvent} e keyboard event object
+  handleKeyEvent: (e) ->
+    @detectAltGrKeyDown(e)
+
+    if process.platform == 'win32'
+      @hasCtrl = !@altGrDown && e.ctrlKey
+      @hasAltGr = @altGrDown
+      @hasAlt = !@altGrDown && e.altKey
+    else if process.platform == 'linux'
+      @hasCtrl = e.ctrlKey
+      @hasAltGr = @altGrDown
+      @hasAlt = e.altKey
+    else
+      @hasCtrl = e.ctrlKey
+      @hasAltGr = e.altKey
+      @hasAlt = e.altKey
+
+  # determine if altgr key is currently held down
+  isAltGr: ->
+    return @hasAltGr
+
+  # determine if alt key is currently held down
+  isAlt: ->
+    return @hasAlt
+
+  # determine if ctrl key is currently held down
+  isCtrl: ->
+    return @hasCtrl
+
+  # get the current state of all modifiers
+  # @return {object}
+  getState: ->
+    altgr: @isAltGr()
+    alt: @isAlt()
+    ctrl: @isCtrl()

--- a/src/modifier-state-handler.coffee
+++ b/src/modifier-state-handler.coffee
@@ -63,7 +63,7 @@ class ModifierStateHandler
     window.removeEventListener 'blur', @clearModifierStateListener
 
   clearModifierState: ->
-    if process.platform = 'win32'
+    if process.platform == 'win32'
       @quitAltGrMode()
     @hasCtrl = false
     @hasAltGr = false
@@ -84,11 +84,11 @@ class ModifierStateHandler
   #
   # @param {!KeyboardEvent} e keyboard event object
   onAltGrUp: (e) ->
-    if process.platform = 'win32'
+    if process.platform == 'win32'
       key = e.keyCode || e.which
       if @altGrDown && key == 17 # 17 = KeyEvent.DOM_VK_CONTROL
         @quitAltGrMode()
-    if process.platform = 'linux'
+    if process.platform == 'linux'
       if e.keyIdentifier == LINUX_ALTGR_IDENTIFIER
         @quitAltGrMode()
 
@@ -103,7 +103,7 @@ class ModifierStateHandler
   #
   # @param {!KeyboardEvent} e keyboard event object
   detectAltGrKeyDown: (e) ->
-    if process.platform = 'win32'
+    if process.platform == 'win32'
       if !@altGrDown
         if @ctrlDown != @CtrlDownStates.DETECTED_AND_IGNORED && e.ctrlKey && e.keyIdentifier == 'Control'
           @ctrlDown = @CtrlDownStates.DETECTED
@@ -130,7 +130,7 @@ class ModifierStateHandler
           @quitAltGrMode()
         else
           @lastKeyIdentifier = e.keyIdentifier
-    if process.platform = 'linux'
+    if process.platform == 'linux'
       if !@altGrDown
         if e.keyIdentifier == LINUX_ALTGR_IDENTIFIER
           @altGrDown = true


### PR DESCRIPTION
This pr is first of all a proof of concept and a startingpoint for fixing #35 

By trying to solve the problem i've implemented a meta modifier handler, that is for a while now part of my atom plugin [keyboard-localization](https://github.com/andischerer/atom-keyboard-localization/blob/master/lib/modifier-state-handler.coffee).

DISCLAIMER: Some parts from `modifier-state-handler` come from [Brackets-Editor](https://github.com/adobe/brackets/commit/f9101ec3c43376a5572bd229aac8e23d058e328a) altgr handling.

TODOs:
- Is there a seperate class for handling modifier state neccessary or should i integrate the altgr logic into existing structures ?
- The algr handling shouldnt conflict us keyboard layouts. Testing neccessary.
    - Should the modifier-handler get activated by a setting ?
    - Should i read the system locale to determine if a keyboard-layout with altgr key is present ?
- What about darwin ? My dev machines are win and linux only
- Specs for altgr handling

Just leave a note if this workaround is too hacky and is going in the wrong direction.
My time is mostly limited, so any support on this is appreciated.