### PR TITLE
Insert printable characters when multi-keystroke bindings fail to match

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-keymap",
   "version": "5.1.6",
   "description": "Atom's DOM-aware keymap module",
-  "main": "./lib/keymap-manager",
+  "main": "./src/keymap-manager",
   "scripts": {
     "prepublish": "grunt prepublish",
     "test": "grunt test",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-keymap",
   "version": "5.1.6",
   "description": "Atom's DOM-aware keymap module",
-  "main": "./src/keymap-manager",
+  "main": "./lib/keymap-manager",
   "scripts": {
     "prepublish": "grunt prepublish",
     "test": "grunt test",

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -225,6 +225,26 @@ describe "KeymapManager", ->
           expect(events).toEqual ['enter-visual-mode']
           expect(clearTimeout).toHaveBeenCalled()
 
+        it "dispatches a text-input event for any replayed keyboard events that would have inserted characters", ->
+          textInputCharacters = []
+          editor.addEventListener 'textInput', (event) -> textInputCharacters.push(event.data)
+
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('i', target: editor))
+          keymapManager.handleKeyboardEvent(lastEvent = buildKeydownEvent('k', target: editor))
+
+          expect(textInputCharacters).toEqual ['i']
+          expect(lastEvent.defaultPrevented).toBe false # inserted as normal
+
+          textInputCharacters = []
+
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('d', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('o', target: editor))
+          keymapManager.handleKeyboardEvent(lastEvent = buildKeydownEvent('q', target: editor))
+
+          expect(textInputCharacters).toEqual ['d', 'o']
+          expect(lastEvent.defaultPrevented).toBe false # inserted as normal
+
       describe "when the currently queued keystrokes exactly match at least one binding", ->
         it "disables partially-matching bindings and replays the queued keystrokes if the ::partialMatchTimeout expires", ->
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -6,5 +6,3 @@ beforeEach ->
 exports.appendContent = (element) ->
   document.querySelector('#jasmine-content').appendChild(element)
   element
-
-require('grim').includeDeprecatedAPIs = false

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -1,4 +1,3 @@
-Grim = require 'grim'
 {calculateSpecificity} = require './helpers'
 
 module.exports =
@@ -25,16 +24,3 @@ class KeyBinding
       keyBinding.index - @index
     else
       keyBinding.specificity - @specificity
-
-if Grim.includeDeprecatedAPIs
-  PropertyAccessors = require 'property-accessors'
-  PropertyAccessors.includeInto(KeyBinding)
-
-  KeyBinding::accessor 'keystroke',
-    get: ->
-      Grim.deprecate('Use KeyBinding.keystrokes instead')
-      @keystrokes
-
-    set: (value) ->
-      Grim.deprecate('Use KeyBinding.keystrokes instead')
-      @keystrokes = value


### PR DESCRIPTION
Refs atom/atom-keymap#17
Fixes atom/vim-mode#221
Fixes atom/vim-mode#334

:pear:ing w/ @nathansobo 