### PR TITLE
Add `unset!` keymaps to `ignoreKeystrokes` set before checking for matches, fixes #78.

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -114,6 +114,18 @@ describe "KeymapManager", ->
           expect(events[0].type).toBe 'x-command'
           expect(event.defaultPrevented).toBe true
 
+      describe "if the matching binding's command is 'unset!' and there is another match", ->
+        it "immediately matches the other match", ->
+          elementA.addEventListener 'unset!', (e) -> events.push(e)
+          keymapManager.add "test",
+            ".a":
+              "ctrl-y": "x-command"
+              "ctrl-y ctrl-y": "unset!"
+          event = buildKeydownEvent('y', ctrl: true, target: elementA)
+          keymapManager.handleKeyboardEvent(event)
+          expect(events.length).toBe 1
+          expect(events[0].type).toBe 'x-command'
+
       describe "if the matching binding's command is 'abort!'", ->
         it "stops searching for a matching binding immediately and emits no command event", ->
           elementA.addEventListener 'abort!', (e) -> events.push(e)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -532,11 +532,13 @@ class KeymapManager
     partialMatches = []
     ignoreKeystrokes = new Set
 
+    partialMatchCandidates.forEach (binding) ->
+      if binding.command is 'unset!'
+        ignoreKeystrokes.add(binding.keystrokes)
+
     while partialMatchCandidates.length > 0 and target? and target isnt document
       partialMatchCandidates = partialMatchCandidates.filter (binding) ->
-        if binding.command is 'unset!'
-          ignoreKeystrokes.add(binding.keystrokes)
-        else if not ignoreKeystrokes.has(binding.keystrokes) and target.webkitMatchesSelector(binding.selector)
+        if not ignoreKeystrokes.has(binding.keystrokes) and target.webkitMatchesSelector(binding.selector)
           partialMatches.push(binding)
           false
         else


### PR DESCRIPTION
Fixes #78.