### PR TITLE
add isAtomModifier to package exports

### DIFF
--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -628,3 +628,8 @@ class KeymapManager
       break if currentTarget is window
       currentTarget = currentTarget.parentNode ? window
     return
+
+  # Public: Returns whether a given keystroke is a modifier (or a combination of modifiers, such as `shift-ctrl`).
+  #
+  # * `keystroke` A {String} of keystrokes in a key binding matching event.
+  isAtomModifier: isAtomModifier


### PR DESCRIPTION
When dealing with key binding matching events, it is useful to be able to ignore failed bindings for modifiers, e.g. in atom/vim-mode#781.
This PR adds `isAtomModifier` to the exports of KeymapManager.