### PR TITLE
Reject empty commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/atom/atom-keymap/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/atom/atom-keymap/raw/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "clear-cut": "^2",
     "emissary": "^1.1.0",

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -428,6 +428,24 @@ describe "KeymapManager", ->
       keymapManager.handleKeyboardEvent(event)
       expect(event.defaultPrevented).toBe false
 
+    it "rejects bindings with an empty command and logs a warning to the console", ->
+      spyOn(console, 'warn')
+      expect(keymapManager.add('test', 'body': 'shift-a': '')).toBeUndefined()
+      expect(console.warn).toHaveBeenCalled()
+
+      event = buildKeydownEvent('A', shift: true, target: document.body)
+      keymapManager.handleKeyboardEvent(event)
+      expect(event.defaultPrevented).toBe false
+
+    it "rejects bindings without a command and logs a warning to the console", ->
+      spyOn(console, 'warn')
+      expect(keymapManager.add('test', 'body': 'shift-a': null)).toBeUndefined()
+      expect(console.warn).toHaveBeenCalled()
+
+      event = buildKeydownEvent('A', shift: true, target: document.body)
+      keymapManager.handleKeyboardEvent(event)
+      expect(event.defaultPrevented).toBe false
+
     it "returns a disposable allowing the added bindings to be removed", ->
       disposable1 = keymapManager.add 'foo',
         '.a':

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -228,6 +228,13 @@ class KeymapManager
         return
 
       for keystrokes, command of keyBindings
+        command = command?.toString() ? ''
+
+        if command.length is 0
+          console.warn "Empty command for binding: `#{keystrokes}` in #{source}"
+          return
+
+        console.log 'adding', keystrokes, command
         if normalizedKeystrokes = normalizeKeystrokes(keystrokes)
           keyBinding = new KeyBinding(source, command, normalizedKeystrokes, selector)
           addedKeyBindings.push(keyBinding)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -231,7 +231,7 @@ class KeymapManager
         command = command?.toString() ? ''
 
         if command.length is 0
-          console.warn "Empty command for binding: `#{keystrokes}` in #{source}"
+          console.warn "Empty command for binding: `#{selector}` `#{keystrokes}` in #{source}"
           return
 
         console.log 'adding', keystrokes, command

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -234,7 +234,6 @@ class KeymapManager
           console.warn "Empty command for binding: `#{selector}` `#{keystrokes}` in #{source}"
           return
 
-        console.log 'adding', keystrokes, command
         if normalizedKeystrokes = normalizeKeystrokes(keystrokes)
           keyBinding = new KeyBinding(source, command, normalizedKeystrokes, selector)
           addedKeyBindings.push(keyBinding)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -228,7 +228,7 @@ class KeymapManager
         return
 
       for keystrokes, command of keyBindings
-        command = command?.toString() ? ''
+        command = command?.toString?() ? ''
 
         if command.length is 0
           console.warn "Empty command for binding: `#{selector}` `#{keystrokes}` in #{source}"


### PR DESCRIPTION
If the command is null or empty than the following error occurs when the keybinding is triggered:

```
At /usr/share/atom/resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:520

Error: Failed to execute 'dispatchEvent' on 'EventTarget': The event provided is uninitialized.
  at Error (native)
  at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/usr/share/atom/resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:520:16)
  at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/usr/share/atom/resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:355:22)
  at HTMLDocument.module.exports.WindowEventHandler.onKeydown (/usr/share/atom/resources/app.asar/src/window-event-handler.js:180:20)
```

This pull request rejects them and logs a warning which mirrors the behavior when the selectors or keystrokes are invalid

Closes atom/atom#7489

/cc @maxbrunsfeld @nathansobo 