### PR TITLE
Keybindings Priority

### DIFF
--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -6,7 +6,7 @@ class KeyBinding
 
   enabled: true
 
-  constructor: (@source, @command, @keystrokes, selector) ->
+  constructor: (@source, @command, @keystrokes, selector, @priority) ->
     @keystrokeCount = @keystrokes.split(' ').length
     @selector = selector.replace(/!important/g, '')
     @specificity = calculateSpecificity(selector)
@@ -21,6 +21,9 @@ class KeyBinding
 
   compare: (keyBinding) ->
     if keyBinding.specificity is @specificity
-      keyBinding.index - @index
+      if keyBinding.priority is @priority
+        keyBinding.index - @index
+      else
+        keyBinding.priority - @priority
     else
       keyBinding.specificity - @specificity

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -332,6 +332,9 @@ class KeymapManager
   #
   # * `path` A {String} containing a path to a file or a directory. If the path is
   #   a directory, all files inside it will be loaded.
+  # * `options` An {Object} containing the following optional keys:
+  #   * `priority` A {Number} used to sort keybindings which have the same
+  #     specificity.
   watchKeymap: (filePath, options) ->
     if not @watchSubscriptions[filePath]? or @watchSubscriptions[filePath].disposed
       file = new File(filePath)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -220,7 +220,7 @@ class KeymapManager
   # * `bindings` An {Object} whose top-level keys point at sub-objects mapping
   #   keystroke patterns to commands.
   # * `priority` A {Number} used to sort keybindings which have the same
-  #   specificity.
+  #   specificity. Defaults to `0`.
   add: (source, keyBindingsBySelector, priority=0) ->
     addedKeyBindings = []
     for selector, keyBindings of keyBindingsBySelector

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -219,7 +219,9 @@ class KeymapManager
   #   so they can be removed later.
   # * `bindings` An {Object} whose top-level keys point at sub-objects mapping
   #   keystroke patterns to commands.
-  add: (source, keyBindingsBySelector) ->
+  # * `priority` A {Number} used to sort keybindings which have the same
+  #   specificity.
+  add: (source, keyBindingsBySelector, priority=0) ->
     addedKeyBindings = []
     for selector, keyBindings of keyBindingsBySelector
       # Verify selector is valid before registering any bindings
@@ -235,7 +237,7 @@ class KeymapManager
           return
 
         if normalizedKeystrokes = normalizeKeystrokes(keystrokes)
-          keyBinding = new KeyBinding(source, command, normalizedKeystrokes, selector)
+          keyBinding = new KeyBinding(source, command, normalizedKeystrokes, selector, priority)
           addedKeyBindings.push(keyBinding)
           @keyBindings.push(keyBinding)
         else


### PR DESCRIPTION
Refs: #100 

This PR introduces a `priority` parameter to give more importance to certain keybindings when there are
other keybindings with the same specificity, as opposed to the current default behavior which lets keybindings that were defined last to win over those that were defined first.

A use-case for this feature in Atom could be user-defined keymaps, because we always want them to win even when adding them e.g. before bundled keymaps or after reloading a package.

/cc: @nathansobo @maxbrunsfeld @atom/feedback 