### PR TITLE
Add handlers for keyup events

### DIFF
--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -16,6 +16,11 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('cmd-shift-a')).toBe 'shift-cmd-A'
     expect(normalizeKeystrokes('cmd-ctrl-alt--')).toBe 'ctrl-alt-cmd--'
 
+    expect(normalizeKeystrokes('ctrl-y   ^y')).toBe 'ctrl-y ^y'
+    expect(normalizeKeystrokes('ctrl-y ^ctrl-y')).toBe 'ctrl-y ^ctrl-y'
+    expect(normalizeKeystrokes('cmd-shift-y ^cmd-shift-y')).toBe 'shift-cmd-Y ^shift-cmd-Y'
+    expect(normalizeKeystrokes('ctrl-y ^ctrl-y ^ctrl')).toBe 'ctrl-y ^ctrl-y ^ctrl'
+
     expect(normalizeKeystrokes('a-b')).toBe false
     expect(normalizeKeystrokes('---')).toBe false
     expect(normalizeKeystrokes('cmd-a-b')).toBe false

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -46,6 +46,7 @@ describe ".keystrokesMatch(bindingKeystrokes, userKeystrokes)", ->
     expect(keystrokesMatch(['a', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
     expect(keystrokesMatch(['a', 'b', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
     expect(keystrokesMatch(['a', 'd', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+    expect(keystrokesMatch(['a', 'd', '^d'], ['^c'])).toBe false
 
   it "returns 'partial' for partial matches", ->
     expect(keystrokesMatch(['a', 'b', 'c'], ['a'])).toBe 'partial'

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -20,6 +20,7 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('ctrl-y ^ctrl-y')).toBe 'ctrl-y ^y'
     expect(normalizeKeystrokes('cmd-shift-y ^cmd-shift-y')).toBe 'shift-cmd-Y ^y'
     expect(normalizeKeystrokes('ctrl-y ^ctrl-y ^ctrl')).toBe 'ctrl-y ^y ^ctrl'
+    expect(normalizeKeystrokes('ctrl-y ^ctrl-shift-alt-cmd-y ^ctrl ^shift ^alt ^cmd')).toBe 'ctrl-y ^y ^ctrl ^shift ^alt ^cmd'
     expect(normalizeKeystrokes('a b c ^a ^b ^c')).toBe 'a b c ^a ^b ^c'
 
     expect(normalizeKeystrokes('a-b')).toBe false

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -17,9 +17,10 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('cmd-ctrl-alt--')).toBe 'ctrl-alt-cmd--'
 
     expect(normalizeKeystrokes('ctrl-y   ^y')).toBe 'ctrl-y ^y'
-    expect(normalizeKeystrokes('ctrl-y ^ctrl-y')).toBe 'ctrl-y ^ctrl-y'
-    expect(normalizeKeystrokes('cmd-shift-y ^cmd-shift-y')).toBe 'shift-cmd-Y ^shift-cmd-Y'
-    expect(normalizeKeystrokes('ctrl-y ^ctrl-y ^ctrl')).toBe 'ctrl-y ^ctrl-y ^ctrl'
+    expect(normalizeKeystrokes('ctrl-y ^ctrl-y')).toBe 'ctrl-y ^y'
+    expect(normalizeKeystrokes('cmd-shift-y ^cmd-shift-y')).toBe 'shift-cmd-Y ^y'
+    expect(normalizeKeystrokes('ctrl-y ^ctrl-y ^ctrl')).toBe 'ctrl-y ^y ^ctrl'
+    expect(normalizeKeystrokes('a b c ^a ^b ^c')).toBe 'a b c ^a ^b ^c'
 
     expect(normalizeKeystrokes('a-b')).toBe false
     expect(normalizeKeystrokes('---')).toBe false

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -1,4 +1,4 @@
-{normalizeKeystrokes} = require '../src/helpers'
+{normalizeKeystrokes, keystrokesMatch} = require '../src/helpers'
 
 describe ".normalizeKeystrokes(keystrokes)", ->
   it "parses and normalizes the keystrokes", ->
@@ -24,3 +24,25 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('--')).toBe false
     expect(normalizeKeystrokes('- ')).toBe false
     expect(normalizeKeystrokes('a ')).toBe false
+
+describe ".keystrokesMatch(bindingKeystrokes, userKeystrokes)", ->
+  it "returns 'exact' for exact matches", ->
+    expect(keystrokesMatch(['ctrl-tab', '^tab', '^ctrl'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
+    expect(keystrokesMatch(['ctrl-tab', '^ctrl'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
+    expect(keystrokesMatch(['ctrl-tab', '^tab'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
+
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe 'exact'
+    expect(keystrokesMatch(['a', 'b', '^b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe 'exact'
+
+  it "returns false for non-matches", ->
+    expect(keystrokesMatch(['a'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+    expect(keystrokesMatch(['a', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+    expect(keystrokesMatch(['a', 'b', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+    expect(keystrokesMatch(['a', 'd', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+
+  it "returns 'partial' for partial matches", ->
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a'])).toBe 'partial'
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a'])).toBe 'partial'
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b'])).toBe 'partial'
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b'])).toBe 'partial'
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'd', '^d'])).toBe false

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -373,13 +373,13 @@ describe "KeymapManager", ->
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['x-ctrl-keyup']
 
-      it "dispatches the y-up-ctrl-keyup command when a matching keystroke precedes it", ->
+      it "dispatches a command when modifier is lifted before the character", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-ctrl-keyup']
 
-      it "doesn't dispatch the y-up-ctrl-keyup command when a non-matching keystroke precedes it", ->
+      it "does not dispatch the keyup command when a non-matching keydown event is made between matching keystrokes", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeydownEvent('z', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -339,7 +339,7 @@ describe "KeymapManager", ->
 
           expect(events).toEqual ['input:d', 'input:o', 'dog']
 
-    describe "when the a binding specifies a keyup handler", ->
+    describe "when the binding specifies a keyup handler", ->
       [events, elementA] = []
 
       beforeEach ->
@@ -368,27 +368,27 @@ describe "KeymapManager", ->
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-up-ctrl-keyup']
 
-      it "dispatches a command when modifier is lifted before the character", ->
+      it "dispatches the command when modifier is lifted before the character", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-ctrl-keyup']
 
-      it "dispatches keyup command when extra user-generated keyup events are not specified in the binding", ->
+      it "dispatches the command when extra user-generated keyup events are not specified in the binding", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('x', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeyupEvent('x', ctrl: true, target: elementA)) # not specified in binding
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['x-ctrl-keyup']
 
-      it "does _not_ dispatch keyup command when extra user-generated keydown events are not specified in the binding", ->
+      it "does _not_ dispatch the command when extra user-generated keydown events are not specified in the binding", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeydownEvent('z', ctrl: true, target: elementA)) # not specified in binding
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-keydown']
 
-      it "dispatches commands with multiple keyup keystrokes specified", ->
+      it "dispatches the command when multiple keyup keystrokes are specified", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: elementA))
         keymapManager.handleKeyboardEvent(buildKeydownEvent('b', target: elementA))
         keymapManager.handleKeyboardEvent(buildKeydownEvent('c', target: elementA))

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -881,7 +881,7 @@ describe "KeymapManager", ->
       expect(partiallyMatchedBindings.map ({command}) -> command).toEqual ['command-1', 'command-2']
       expect(keyboardEventTarget).toBe document.body
 
-    it "emits `matched-partially` when a key binding partially matches an event for key bindings that have keyup events", ->
+    it "emits `matched-partially` when a key binding that contains keyup keystrokes partially matches an event", ->
       handler = jasmine.createSpy('matched-partially handler')
       keymapManager.onDidPartiallyMatchBindings handler
       keymapManager.add "test",

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -225,9 +225,13 @@ describe "KeymapManager", ->
       describe "when subsequent keystrokes yield an exact match", ->
         it "dispatches the command associated with the matched multi-keystroke binding", ->
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('v', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('i', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('i', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('v', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: editor))
           expect(events).toEqual ['viva!']
 
       describe "when subsequent keystrokes yield no matches", ->

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -366,22 +366,22 @@ describe "KeymapManager", ->
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-up-ctrl-keyup']
 
-      it "dispatches a command when the keybinding does not specify all key up events", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('x', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('x', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual ['x-ctrl-keyup']
-
       it "dispatches a command when modifier is lifted before the character", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-ctrl-keyup']
 
-      it "does not dispatch the keyup command when a non-matching keydown event is made between matching keystrokes", ->
+      it "dispatches keyup command when extra user-generated keyup events are not specified in the binding", ->
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('x', ctrl: true, target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('x', ctrl: true, target: elementA)) # not specified in binding
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
+        advanceClock(keymapManager.getPartialMatchTimeout())
+        expect(events).toEqual ['x-ctrl-keyup']
+
+      it "does _not_ dispatch keyup command when extra user-generated keydown events are not specified in the binding", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('z', ctrl: true, target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('z', ctrl: true, target: elementA)) # not specified in binding
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-keydown']

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -363,7 +363,7 @@ describe "KeymapManager", ->
 
       it "dispatches the command when a matching keystroke precedes it", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('y', ctrl: true, target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('y', ctrl: true, cmd: true, shift: true, alt: true, target: elementA))
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-up-ctrl-keyup']

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -358,7 +358,7 @@ describe "KeymapManager", ->
             "ctrl-y": "y-command"
             "ctrl-y ^ctrl": "y-command-ctrl-up"
             "ctrl-x ^ctrl": "x-command-ctrl-up"
-            "ctrl-y ^ctrl-y ^ctrl": "y-command-y-up-ctrl-up"
+            "ctrl-y ^y ^ctrl": "y-command-y-up-ctrl-up"
             "a b c ^b ^a ^c": "abc-secret-code-command"
 
       it "dispatches the command when a matching keystroke precedes it", ->

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -881,7 +881,7 @@ describe "KeymapManager", ->
       expect(partiallyMatchedBindings.map ({command}) -> command).toEqual ['command-1', 'command-2']
       expect(keyboardEventTarget).toBe document.body
 
-    fit "emits `matched-partially` when a key binding partially matches an event for key bindings that have keyup events", ->
+    it "emits `matched-partially` when a key binding partially matches an event for key bindings that have keyup events", ->
       handler = jasmine.createSpy('matched-partially handler')
       keymapManager.onDidPartiallyMatchBindings handler
       keymapManager.add "test",

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -429,9 +429,9 @@ describe "KeymapManager", ->
 
       # Simulate keydown events for the modifier key being pressed on its own
       # prior to the key it is modifying.
-      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', target: element))
+      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', ctrl: true, target: element))
       keymapManager.handleKeyboardEvent(buildKeydownEvent('a', ctrl: true, target: element))
-      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', target: element))
+      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', ctrl: true, target: element))
       keymapManager.handleKeyboardEvent(buildKeydownEvent('alt', ctrl: true, target: element))
       keymapManager.handleKeyboardEvent(buildKeydownEvent('b', ctrl: true, alt: true, target: element))
 

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -351,6 +351,7 @@ describe "KeymapManager", ->
         elementA.addEventListener 'y-command-ctrl-up', (e) -> events.push('y-ctrl-keyup')
         elementA.addEventListener 'x-command-ctrl-up', (e) -> events.push('x-ctrl-keyup')
         elementA.addEventListener 'y-command-y-up-ctrl-up', (e) -> events.push('y-up-ctrl-keyup')
+        elementA.addEventListener 'abc-secret-code-command', (e) -> events.push('abc-secret-code')
 
         keymapManager.add "test",
           ".a":
@@ -358,6 +359,7 @@ describe "KeymapManager", ->
             "ctrl-y ^ctrl": "y-command-ctrl-up"
             "ctrl-x ^ctrl": "x-command-ctrl-up"
             "ctrl-y ^ctrl-y ^ctrl": "y-command-y-up-ctrl-up"
+            "a b c ^b ^a ^c": "abc-secret-code-command"
 
       it "dispatches the command when a matching keystroke precedes it", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
@@ -385,6 +387,25 @@ describe "KeymapManager", ->
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-keydown']
+
+      it "dispatches commands with multiple keyup keystrokes specified", ->
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('b', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('c', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('b', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('c', target: elementA))
+        advanceClock(keymapManager.getPartialMatchTimeout())
+        expect(events).toEqual []
+
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('b', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeydownEvent('c', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('b', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: elementA))
+        keymapManager.handleKeyboardEvent(buildKeyupEvent('c', target: elementA))
+        advanceClock(keymapManager.getPartialMatchTimeout())
+        expect(events).toEqual ['abc-secret-code']
 
     it "only counts entire keystrokes when checking for partial matches", ->
       element = $$ -> @div class: 'a'

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -191,13 +191,16 @@ exports.keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target
 # bindingKeystrokes and userKeystrokes are arrays of keystrokes
 exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
   userKeystrokeIndex = -1
+  userKeystrokesHasKeydownEvent = false
   matchesNextStroke = (stroke) ->
     while userKeystrokeIndex < userKeystrokes.length - 1
       userKeystrokeIndex += 1
       userKeystroke = userKeystrokes[userKeystrokeIndex]
+      isKeydownEvent = not userKeystroke.startsWith('^')
+      userKeystrokesHasKeydownEvent = true if isKeydownEvent
       if stroke is userKeystroke
         return true
-      else unless userKeystroke.startsWith('^')
+      else if isKeydownEvent
         return false
     null
 
@@ -206,7 +209,11 @@ exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
     if doesMatch is false
       return false
     else if doesMatch is null
-      return PartialMatch
+      # If there are only keyup events, it will partial match everything :/
+      if userKeystrokesHasKeydownEvent
+        return PartialMatch
+      else
+        return false
 
   while userKeystrokeIndex < userKeystrokes.length - 1
     userKeystrokeIndex += 1

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -189,7 +189,7 @@ keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, locati
   event
 
 # bindingKeystrokes and userKeystrokes are arrays of keystrokes
-# e.g. ['crtl-y', 'ctrl-x', '^x']
+# e.g. ['ctrl-y', 'ctrl-x', '^x']
 exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
   userKeystrokeIndex = -1
   userKeystrokesHasKeydownEvent = false

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -148,10 +148,10 @@ exports.isAtomModifier = (keystroke) ->
   AtomModifiers.has(keystroke) or AtomModifierRegex.test(keystroke)
 
 exports.keydownEvent = (key, options) ->
-  return exports.keyboardEvent(key, 'keydown', options)
+  return keyboardEvent(key, 'keydown', options)
 
 exports.keyupEvent = (key, options) ->
-  return exports.keyboardEvent(key, 'keyup', options)
+  return keyboardEvent(key, 'keyup', options)
 
 keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
   event = document.createEvent('KeyboardEvent')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -153,7 +153,7 @@ exports.keydownEvent = (key, options) ->
 exports.keyupEvent = (key, options) ->
   return exports.keyboardEvent(key, 'keyup', options)
 
-exports.keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
+keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
   event = document.createEvent('KeyboardEvent')
   bubbles = true
   cancelable = true

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -233,9 +233,12 @@ normalizeKeystroke = (keystroke) ->
       else
         return false
 
-  modifiers.add('shift') if UpperCaseLetterRegex.test(primaryKey)
-  if not isKeyup and modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
-    primaryKey = primaryKey.toUpperCase()
+  if isKeyup
+    primaryKey = primaryKey.toLowerCase() if primaryKey?
+  else
+    modifiers.add('shift') if UpperCaseLetterRegex.test(primaryKey)
+    if modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
+      primaryKey = primaryKey.toUpperCase()
 
   keystroke = []
   if not isKeyup or (isKeyup and not primaryKey?)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -210,7 +210,7 @@ exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
     if doesMatch is false
       return false
     else if doesMatch is null
-      # Make userKeystrokes with only keyup events doesn't match everything
+      # Make sure userKeystrokes with only keyup events doesn't match everything
       if userKeystrokesHasKeydownEvent
         return PartialMatch
       else

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -214,6 +214,8 @@ exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
   ExactMatch
 
 normalizeKeystroke = (keystroke) ->
+  if isKeyup = keystroke.startsWith('^')
+    keystroke = keystroke.slice(1)
   keys = parseKeystroke(keystroke)
   return false unless keys
 
@@ -240,7 +242,9 @@ normalizeKeystroke = (keystroke) ->
   keystroke.push('shift') if modifiers.has('shift')
   keystroke.push('cmd') if modifiers.has('cmd')
   keystroke.push(primaryKey) if primaryKey?
-  keystroke.join('-')
+  keystroke = keystroke.join('-')
+  keystroke = "^#{keystroke}" if isKeyup
+  keystroke
 
 parseKeystroke = (keystroke) ->
   keys = []

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -115,20 +115,20 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
   key = keyForKeyboardEvent(event, dvorakQwertyWorkaroundEnabled)
 
   keystroke = ''
-  if event.ctrlKey
+  if event.ctrlKey or key is 'Control'
     keystroke += 'ctrl'
-  if event.altKey
+  if event.altKey or key is 'Alt'
     keystroke += '-' if keystroke
     keystroke += 'alt'
-  if event.shiftKey
+  if event.shiftKey or key is 'Shift'
     # Don't push 'shift' when modifying symbolic characters like '{'
     unless /^[^A-Za-z]$/.test(key)
       keystroke += '-' if keystroke
       keystroke += 'shift'
-  if event.metaKey
+  if event.metaKey or key is 'Meta'
     keystroke += '-' if keystroke
     keystroke += 'cmd'
-  if key?
+  if key? and not KeyboardEventModifiers.has(key)
     keystroke += '-' if keystroke
     keystroke += key
 
@@ -163,16 +163,16 @@ exports.keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target
     switch key
       when 'ctrl'
         keyIdentifier = 'Control'
-        ctrl = true
+        ctrl = true if eventType isnt 'keyup'
       when 'alt'
         keyIdentifier = 'Alt'
-        alt = true
+        alt = true if eventType isnt 'keyup'
       when 'shift'
         keyIdentifier = 'Shift'
-        shift = true
+        shift = true if eventType isnt 'keyup'
       when 'cmd'
         keyIdentifier = 'Meta'
-        cmd = true
+        cmd = true if eventType isnt 'keyup'
       else
         keyIdentifier = key[0].toUpperCase() + key[1..]
 
@@ -232,7 +232,7 @@ keyForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
   if process.platform in ['linux', 'win32']
     keyIdentifier = translateKeyIdentifierForWindowsAndLinuxChromiumBug(keyIdentifier)
 
-  return null if KeyboardEventModifiers.has(keyIdentifier)
+  return keyIdentifier if KeyboardEventModifiers.has(keyIdentifier)
 
   charCode = charCodeFromKeyIdentifier(keyIdentifier)
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -144,7 +144,13 @@ exports.calculateSpecificity = calculateSpecificity
 exports.isAtomModifier = (keystroke) ->
   AtomModifiers.has(keystroke) or AtomModifierRegex.test(keystroke)
 
-exports.keydownEvent = (key, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
+exports.keydownEvent = (key, options) ->
+  return exports.keyboardEvent(key, 'keydown', options)
+
+exports.keyupEvent = (key, options) ->
+  return exports.keyboardEvent(key, 'keyup', options)
+
+exports.keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
   event = document.createEvent('KeyboardEvent')
   bubbles = true
   cancelable = true
@@ -171,7 +177,7 @@ exports.keydownEvent = (key, {ctrl, shift, alt, cmd, keyCode, target, location}=
         keyIdentifier = key[0].toUpperCase() + key[1..]
 
   location ?= KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-  event.initKeyboardEvent('keydown', bubbles, cancelable, view,  keyIdentifier, location, ctrl, alt, shift, cmd)
+  event.initKeyboardEvent(eventType, bubbles, cancelable, view,  keyIdentifier, location, ctrl, alt, shift, cmd)
   if target?
     Object.defineProperty(event, 'target', get: -> target)
     Object.defineProperty(event, 'path', get: -> [target])

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -7,6 +7,8 @@ AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
 WhitespaceRegex = /\s+/
 LowerCaseLetterRegex = /^[a-z]$/
 UpperCaseLetterRegex = /^[A-Z]$/
+ExactMatch = 'exact'
+PartialMatch = 'partial'
 
 KeyboardEventModifiers = new Set
 KeyboardEventModifiers.add(modifier) for modifier in ['Control', 'Alt', 'Shift', 'Meta']
@@ -184,6 +186,32 @@ exports.keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target
   Object.defineProperty(event, 'keyCode', get: -> keyCode)
   Object.defineProperty(event, 'which', get: -> keyCode)
   event
+
+# bindingKeystrokes and userKeystrokes are arrays of keystrokes
+exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
+  userKeystrokeIndex = -1
+  matchesNextStroke = (stroke) ->
+    while userKeystrokeIndex < userKeystrokes.length - 1
+      userKeystrokeIndex += 1
+      userKeystroke = userKeystrokes[userKeystrokeIndex]
+      if stroke is userKeystroke
+        return true
+      else unless userKeystroke.startsWith('^')
+        return false
+    null
+
+  for bindingKeystroke in bindingKeystrokes
+    doesMatch = matchesNextStroke(bindingKeystroke)
+    if doesMatch is false
+      return false
+    else if doesMatch is null
+      return PartialMatch
+
+  while userKeystrokeIndex < userKeystrokes.length - 1
+    userKeystrokeIndex += 1
+    return false unless userKeystrokes[userKeystrokeIndex].startsWith('^')
+
+  ExactMatch
 
 normalizeKeystroke = (keystroke) ->
   keys = parseKeystroke(keystroke)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -189,32 +189,34 @@ exports.keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target
   event
 
 # bindingKeystrokes and userKeystrokes are arrays of keystrokes
+# e.g. ['crtl-y', 'ctrl-x', '^x']
 exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
   userKeystrokeIndex = -1
   userKeystrokesHasKeydownEvent = false
-  matchesNextStroke = (stroke) ->
+  matchesNextUserKeystroke = (bindingKeystroke) ->
     while userKeystrokeIndex < userKeystrokes.length - 1
       userKeystrokeIndex += 1
       userKeystroke = userKeystrokes[userKeystrokeIndex]
       isKeydownEvent = not userKeystroke.startsWith('^')
       userKeystrokesHasKeydownEvent = true if isKeydownEvent
-      if stroke is userKeystroke
+      if bindingKeystroke is userKeystroke
         return true
       else if isKeydownEvent
         return false
     null
 
   for bindingKeystroke in bindingKeystrokes
-    doesMatch = matchesNextStroke(bindingKeystroke)
+    doesMatch = matchesNextUserKeystroke(bindingKeystroke)
     if doesMatch is false
       return false
     else if doesMatch is null
-      # If there are only keyup events, it will partial match everything :/
+      # Make userKeystrokes with only keyup events doesn't match everything
       if userKeystrokesHasKeydownEvent
         return PartialMatch
       else
         return false
 
+  # Prevent binding of ['a'] from exact matching a user pattern of ['a', '^a', 'b', '^b']
   while userKeystrokeIndex < userKeystrokes.length - 1
     userKeystrokeIndex += 1
     return false unless userKeystrokes[userKeystrokeIndex].startsWith('^')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -134,6 +134,7 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
     keystroke += '-' if keystroke
     keystroke += key
 
+  keystroke = normalizeKeystroke("^#{keystroke}") if event.type is 'keyup'
   keystroke
 
 exports.characterForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
@@ -233,14 +234,15 @@ normalizeKeystroke = (keystroke) ->
         return false
 
   modifiers.add('shift') if UpperCaseLetterRegex.test(primaryKey)
-  if modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
+  if not isKeyup and modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
     primaryKey = primaryKey.toUpperCase()
 
   keystroke = []
-  keystroke.push('ctrl') if modifiers.has('ctrl')
-  keystroke.push('alt') if modifiers.has('alt')
-  keystroke.push('shift') if modifiers.has('shift')
-  keystroke.push('cmd') if modifiers.has('cmd')
+  if not isKeyup or (isKeyup and not primaryKey?)
+    keystroke.push('ctrl') if modifiers.has('ctrl')
+    keystroke.push('alt') if modifiers.has('alt')
+    keystroke.push('shift') if modifiers.has('shift')
+    keystroke.push('cmd') if modifiers.has('cmd')
   keystroke.push(primaryKey) if primaryKey?
   keystroke = keystroke.join('-')
   keystroke = "^#{keystroke}" if isKeyup

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -7,7 +7,8 @@ class KeyBinding
   enabled: true
 
   constructor: (@source, @command, @keystrokes, selector, @priority) ->
-    @keystrokeCount = @keystrokes.split(' ').length
+    @keystrokeArray = @keystrokes.split(' ')
+    @keystrokeCount = @keystrokeArray.length
     @selector = selector.replace(/!important/g, '')
     @specificity = calculateSpecificity(selector)
     @index = @constructor.currentIndex++

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -411,7 +411,6 @@ class KeymapManager
   # * `event` A `KeyboardEvent` of type 'keydown'
   handleKeyboardEvent: (event) ->
     keystroke = @keystrokeForKeyboardEvent(event)
-    keystroke = "^#{keystroke}" if event.type is 'keyup'
 
     if event.type isnt 'keyup' and @queuedKeystrokes.length > 0 and isAtomModifier(keystroke)
       event.preventDefault()

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -416,9 +416,13 @@ class KeymapManager
       event.preventDefault()
       return
 
-    @queuedKeyboardEvents.push(event)
-    @queuedKeystrokes.push(keystroke)
-    keystrokes = @queuedKeystrokes.join(' ')
+    if event.type is 'keyup'
+      keystrokes = "#{@lastKeydownKeystrokes}^#{keystroke}"
+    else
+      @queuedKeyboardEvents.push(event)
+      @queuedKeystrokes.push(keystroke)
+      keystrokes = @queuedKeystrokes.join(' ')
+      @lastKeydownKeystrokes = keystrokes
 
     # If the event's target is document.body, assign it to defaultTarget instead
     # to provide a catch-all element when nothing is focused.

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -7,7 +7,7 @@ path = require 'path'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
 KeyBinding = require './key-binding'
 CommandEvent = require './command-event'
-{normalizeKeystrokes, keystrokeForKeyboardEvent, isAtomModifier, keydownEvent, characterForKeyboardEvent} = require './helpers'
+{normalizeKeystrokes, keystrokeForKeyboardEvent, isAtomModifier, keydownEvent, keyupEvent, characterForKeyboardEvent} = require './helpers'
 
 Platforms = ['darwin', 'freebsd', 'linux', 'sunos', 'win32']
 OtherPlatforms = Platforms.filter (platform) -> platform isnt process.platform
@@ -81,6 +81,8 @@ class KeymapManager
   #     the docs for KeyboardEvent for more information.
   #   * `target` The target element of the event.
   @buildKeydownEvent: (key, options) -> keydownEvent(key, options)
+
+  @buildKeyupEvent: (key, options) -> keyupEvent(key, options)
 
   ###
   Section: Properties

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -460,6 +460,7 @@ class KeymapManager
           if @dispatchCommandEvent(exactMatch.command, target, event)
             @emitter.emit 'did-match-binding', {
               keystrokes,
+              eventType: event.type,
               binding: exactMatch,
               keyboardEventTarget: target
             }
@@ -482,12 +483,14 @@ class KeymapManager
       @enterPendingState(partialMatches, enableTimeout)
       @emitter.emit 'did-partially-match-binding', {
         keystrokes,
+        eventType: event.type,
         partiallyMatchedBindings: partialMatches,
         keyboardEventTarget: target
       }
     else
       @emitter.emit 'did-fail-to-match-binding', {
         keystrokes,
+        eventType: event.type,
         keyboardEventTarget: target
       }
       if @pendingPartialMatches?


### PR DESCRIPTION
This adds new syntax for dispatching commands on keyup events. It looks like this:

```coffee
'atom-workspace':
  'ctrl-y ^ctrl': 'core:do-stuff'
```

Which means, user presses `ctrl-y`, then lifts `ctrl` to fire the command. If any other keybinding is used instead of or after the `ctrl-y`, the command will not be dispatched.

It also handles specifying multiple keyup events in a sequence like this:

```coffee
'atom-workspace':
  'a b c ^c ^a ^b': 'core:secret-triple-command'
```

Press `a`, `b`, `c`, then release `c`, `a`, `b` and :sparkles:. But if you release `a`, `b`, `c` it wont dispatch the command.

And finally, keyup events are handled in a much looser way than keydown events. They can be omitted from the binding. e.g.

```coffee
'atom-workspace':
  'ctrl-y ^ctrl': 'core:do-stuff'
```

This command will still fire when you `ctrl-y`, lift `y`, _then_ lift `ctrl` even though an exact binding for the user sequence would be `'ctrl-y ^y ^ctrl'`.

To make these work, the keyup events are run through the `handleKeyboardEvent` function as well as the keydown events.

A couple things:

* The keybinding resolver will show the keyup events which are not useful 99% of the time and will mask the events that people only care about.
  * Thinking maybe passing the event type through the events emitted by the KeymapManager, then having the keybinding resolver only show keyup events that have been matched.

This is to enable MRU tabs in https://github.com/atom/atom/pull/10737

cc @natalieogle