### PR TITLE
Revert "Add handlers for keyup events"

### DIFF
--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -1,4 +1,4 @@
-{normalizeKeystrokes, keystrokesMatch} = require '../src/helpers'
+{normalizeKeystrokes} = require '../src/helpers'
 
 describe ".normalizeKeystrokes(keystrokes)", ->
   it "parses and normalizes the keystrokes", ->
@@ -16,13 +16,6 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('cmd-shift-a')).toBe 'shift-cmd-A'
     expect(normalizeKeystrokes('cmd-ctrl-alt--')).toBe 'ctrl-alt-cmd--'
 
-    expect(normalizeKeystrokes('ctrl-y   ^y')).toBe 'ctrl-y ^y'
-    expect(normalizeKeystrokes('ctrl-y ^ctrl-y')).toBe 'ctrl-y ^y'
-    expect(normalizeKeystrokes('cmd-shift-y ^cmd-shift-y')).toBe 'shift-cmd-Y ^y'
-    expect(normalizeKeystrokes('ctrl-y ^ctrl-y ^ctrl')).toBe 'ctrl-y ^y ^ctrl'
-    expect(normalizeKeystrokes('ctrl-y ^ctrl-shift-alt-cmd-y ^ctrl ^shift ^alt ^cmd')).toBe 'ctrl-y ^y ^ctrl ^shift ^alt ^cmd'
-    expect(normalizeKeystrokes('a b c ^a ^b ^c')).toBe 'a b c ^a ^b ^c'
-
     expect(normalizeKeystrokes('a-b')).toBe false
     expect(normalizeKeystrokes('---')).toBe false
     expect(normalizeKeystrokes('cmd-a-b')).toBe false
@@ -31,26 +24,3 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     expect(normalizeKeystrokes('--')).toBe false
     expect(normalizeKeystrokes('- ')).toBe false
     expect(normalizeKeystrokes('a ')).toBe false
-
-describe ".keystrokesMatch(bindingKeystrokes, userKeystrokes)", ->
-  it "returns 'exact' for exact matches", ->
-    expect(keystrokesMatch(['ctrl-tab', '^tab', '^ctrl'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
-    expect(keystrokesMatch(['ctrl-tab', '^ctrl'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
-    expect(keystrokesMatch(['ctrl-tab', '^tab'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
-
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe 'exact'
-    expect(keystrokesMatch(['a', 'b', '^b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe 'exact'
-
-  it "returns false for non-matches", ->
-    expect(keystrokesMatch(['a'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
-    expect(keystrokesMatch(['a', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
-    expect(keystrokesMatch(['a', 'b', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
-    expect(keystrokesMatch(['a', 'd', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
-    expect(keystrokesMatch(['a', 'd', '^d'], ['^c'])).toBe false
-
-  it "returns 'partial' for partial matches", ->
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a'])).toBe 'partial'
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a'])).toBe 'partial'
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b'])).toBe 'partial'
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b'])).toBe 'partial'
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'd', '^d'])).toBe false

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -4,7 +4,7 @@ temp = require 'temp'
 {$$} = require 'space-pencil'
 {appendContent} = require './spec-helper'
 KeymapManager = require '../src/keymap-manager'
-{buildKeydownEvent, buildKeyupEvent} = KeymapManager
+{buildKeydownEvent} = KeymapManager
 
 describe "KeymapManager", ->
   keymapManager = null
@@ -225,13 +225,9 @@ describe "KeymapManager", ->
       describe "when subsequent keystrokes yield an exact match", ->
         it "dispatches the command associated with the matched multi-keystroke binding", ->
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
-          keymapManager.handleKeyboardEvent(buildKeyupEvent('v', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('i', target: editor))
-          keymapManager.handleKeyboardEvent(buildKeyupEvent('i', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
-          keymapManager.handleKeyboardEvent(buildKeyupEvent('v', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: editor))
-          keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: editor))
           expect(events).toEqual ['viva!']
 
       describe "when subsequent keystrokes yield no matches", ->
@@ -339,74 +335,6 @@ describe "KeymapManager", ->
 
           expect(events).toEqual ['input:d', 'input:o', 'dog']
 
-    describe "when the binding specifies a keyup handler", ->
-      [events, elementA] = []
-
-      beforeEach ->
-        elementA = appendContent $$ ->
-          @div class: 'a'
-
-        events = []
-        elementA.addEventListener 'y-command', (e) -> events.push('y-keydown')
-        elementA.addEventListener 'y-command-ctrl-up', (e) -> events.push('y-ctrl-keyup')
-        elementA.addEventListener 'x-command-ctrl-up', (e) -> events.push('x-ctrl-keyup')
-        elementA.addEventListener 'y-command-y-up-ctrl-up', (e) -> events.push('y-up-ctrl-keyup')
-        elementA.addEventListener 'abc-secret-code-command', (e) -> events.push('abc-secret-code')
-
-        keymapManager.add "test",
-          ".a":
-            "ctrl-y": "y-command"
-            "ctrl-y ^ctrl": "y-command-ctrl-up"
-            "ctrl-x ^ctrl": "x-command-ctrl-up"
-            "ctrl-y ^y ^ctrl": "y-command-y-up-ctrl-up"
-            "a b c ^b ^a ^c": "abc-secret-code-command"
-
-      it "dispatches the command when a matching keystroke precedes it", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('y', ctrl: true, cmd: true, shift: true, alt: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual ['y-up-ctrl-keyup']
-
-      it "dispatches the command when modifier is lifted before the character", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual ['y-ctrl-keyup']
-
-      it "dispatches the command when extra user-generated keyup events are not specified in the binding", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('x', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('x', ctrl: true, target: elementA)) # not specified in binding
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual ['x-ctrl-keyup']
-
-      it "does _not_ dispatch the command when extra user-generated keydown events are not specified in the binding", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('z', ctrl: true, target: elementA)) # not specified in binding
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual ['y-keydown']
-
-      it "dispatches the command when multiple keyup keystrokes are specified", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('b', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('c', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('b', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('c', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual []
-
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('b', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('c', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('b', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('c', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual ['abc-secret-code']
-
     it "only counts entire keystrokes when checking for partial matches", ->
       element = $$ -> @div class: 'a'
       keymapManager.add 'test',
@@ -429,9 +357,9 @@ describe "KeymapManager", ->
 
       # Simulate keydown events for the modifier key being pressed on its own
       # prior to the key it is modifying.
-      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', ctrl: true, target: element))
+      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', target: element))
       keymapManager.handleKeyboardEvent(buildKeydownEvent('a', ctrl: true, target: element))
-      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', ctrl: true, target: element))
+      keymapManager.handleKeyboardEvent(buildKeydownEvent('ctrl', target: element))
       keymapManager.handleKeyboardEvent(buildKeydownEvent('alt', ctrl: true, target: element))
       keymapManager.handleKeyboardEvent(buildKeydownEvent('b', ctrl: true, alt: true, target: element))
 
@@ -870,7 +798,6 @@ describe "KeymapManager", ->
         "body":
           "ctrl-x 1": "command-1"
           "ctrl-x 2": "command-2"
-          "a c ^c ^a": "command-3"
 
       keymapManager.handleKeyboardEvent(buildKeydownEvent('x', ctrl: true, target: document.body))
       expect(handler).toHaveBeenCalled()
@@ -879,36 +806,6 @@ describe "KeymapManager", ->
       expect(keystrokes).toBe 'ctrl-x'
       expect(partiallyMatchedBindings).toHaveLength 2
       expect(partiallyMatchedBindings.map ({command}) -> command).toEqual ['command-1', 'command-2']
-      expect(keyboardEventTarget).toBe document.body
-
-    it "emits `matched-partially` when a key binding that contains keyup keystrokes partially matches an event", ->
-      handler = jasmine.createSpy('matched-partially handler')
-      keymapManager.onDidPartiallyMatchBindings handler
-      keymapManager.add "test",
-        "body":
-          "a c ^c ^a": "command-1"
-
-      keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: document.body))
-      keymapManager.handleKeyboardEvent(buildKeydownEvent('c', target: document.body))
-      expect(handler).toHaveBeenCalled()
-
-      {keystrokes, partiallyMatchedBindings, keyboardEventTarget} = handler.argsForCall[0][0]
-      expect(keystrokes).toBe 'a'
-
-      {keystrokes, partiallyMatchedBindings, keyboardEventTarget} = handler.argsForCall[1][0]
-      expect(keystrokes).toBe 'a c'
-      expect(partiallyMatchedBindings).toHaveLength 1
-      expect(partiallyMatchedBindings.map ({command}) -> command).toEqual ['command-1']
-      expect(keyboardEventTarget).toBe document.body
-
-      handler.reset()
-      keymapManager.handleKeyboardEvent(buildKeyupEvent('c', target: document.body))
-      expect(handler).toHaveBeenCalled()
-
-      {keystrokes, partiallyMatchedBindings, keyboardEventTarget} = handler.argsForCall[0][0]
-      expect(keystrokes).toBe 'a c ^c'
-      expect(partiallyMatchedBindings).toHaveLength 1
-      expect(partiallyMatchedBindings.map ({command}) -> command).toEqual ['command-1']
       expect(keyboardEventTarget).toBe document.body
 
     it "emits `match-failed` when no key bindings match the event", ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -7,8 +7,6 @@ AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
 WhitespaceRegex = /\s+/
 LowerCaseLetterRegex = /^[a-z]$/
 UpperCaseLetterRegex = /^[A-Z]$/
-ExactMatch = 'exact'
-PartialMatch = 'partial'
 
 KeyboardEventModifiers = new Set
 KeyboardEventModifiers.add(modifier) for modifier in ['Control', 'Alt', 'Shift', 'Meta']
@@ -117,24 +115,23 @@ exports.keystrokeForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
   key = keyForKeyboardEvent(event, dvorakQwertyWorkaroundEnabled)
 
   keystroke = ''
-  if event.ctrlKey or key is 'Control'
+  if event.ctrlKey
     keystroke += 'ctrl'
-  if event.altKey or key is 'Alt'
+  if event.altKey
     keystroke += '-' if keystroke
     keystroke += 'alt'
-  if event.shiftKey or key is 'Shift'
+  if event.shiftKey
     # Don't push 'shift' when modifying symbolic characters like '{'
     unless /^[^A-Za-z]$/.test(key)
       keystroke += '-' if keystroke
       keystroke += 'shift'
-  if event.metaKey or key is 'Meta'
+  if event.metaKey
     keystroke += '-' if keystroke
     keystroke += 'cmd'
-  if key? and not KeyboardEventModifiers.has(key)
+  if key?
     keystroke += '-' if keystroke
     keystroke += key
 
-  keystroke = normalizeKeystroke("^#{keystroke}") if event.type is 'keyup'
   keystroke
 
 exports.characterForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
@@ -147,13 +144,7 @@ exports.calculateSpecificity = calculateSpecificity
 exports.isAtomModifier = (keystroke) ->
   AtomModifiers.has(keystroke) or AtomModifierRegex.test(keystroke)
 
-exports.keydownEvent = (key, options) ->
-  return keyboardEvent(key, 'keydown', options)
-
-exports.keyupEvent = (key, options) ->
-  return keyboardEvent(key, 'keyup', options)
-
-keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
+exports.keydownEvent = (key, {ctrl, shift, alt, cmd, keyCode, target, location}={}) ->
   event = document.createEvent('KeyboardEvent')
   bubbles = true
   cancelable = true
@@ -166,21 +157,21 @@ keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, locati
     switch key
       when 'ctrl'
         keyIdentifier = 'Control'
-        ctrl = true if eventType isnt 'keyup'
+        ctrl = true
       when 'alt'
         keyIdentifier = 'Alt'
-        alt = true if eventType isnt 'keyup'
+        alt = true
       when 'shift'
         keyIdentifier = 'Shift'
-        shift = true if eventType isnt 'keyup'
+        shift = true
       when 'cmd'
         keyIdentifier = 'Meta'
-        cmd = true if eventType isnt 'keyup'
+        cmd = true
       else
         keyIdentifier = key[0].toUpperCase() + key[1..]
 
   location ?= KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-  event.initKeyboardEvent(eventType, bubbles, cancelable, view,  keyIdentifier, location, ctrl, alt, shift, cmd)
+  event.initKeyboardEvent('keydown', bubbles, cancelable, view,  keyIdentifier, location, ctrl, alt, shift, cmd)
   if target?
     Object.defineProperty(event, 'target', get: -> target)
     Object.defineProperty(event, 'path', get: -> [target])
@@ -188,44 +179,7 @@ keyboardEvent = (key, eventType, {ctrl, shift, alt, cmd, keyCode, target, locati
   Object.defineProperty(event, 'which', get: -> keyCode)
   event
 
-# bindingKeystrokes and userKeystrokes are arrays of keystrokes
-# e.g. ['ctrl-y', 'ctrl-x', '^x']
-exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
-  userKeystrokeIndex = -1
-  userKeystrokesHasKeydownEvent = false
-  matchesNextUserKeystroke = (bindingKeystroke) ->
-    while userKeystrokeIndex < userKeystrokes.length - 1
-      userKeystrokeIndex += 1
-      userKeystroke = userKeystrokes[userKeystrokeIndex]
-      isKeydownEvent = not userKeystroke.startsWith('^')
-      userKeystrokesHasKeydownEvent = true if isKeydownEvent
-      if bindingKeystroke is userKeystroke
-        return true
-      else if isKeydownEvent
-        return false
-    null
-
-  for bindingKeystroke in bindingKeystrokes
-    doesMatch = matchesNextUserKeystroke(bindingKeystroke)
-    if doesMatch is false
-      return false
-    else if doesMatch is null
-      # Make sure userKeystrokes with only keyup events doesn't match everything
-      if userKeystrokesHasKeydownEvent
-        return PartialMatch
-      else
-        return false
-
-  # Prevent binding of ['a'] from exact matching a user pattern of ['a', '^a', 'b', '^b']
-  while userKeystrokeIndex < userKeystrokes.length - 1
-    userKeystrokeIndex += 1
-    return false unless userKeystrokes[userKeystrokeIndex].startsWith('^')
-
-  ExactMatch
-
 normalizeKeystroke = (keystroke) ->
-  if isKeyup = keystroke.startsWith('^')
-    keystroke = keystroke.slice(1)
   keys = parseKeystroke(keystroke)
   return false unless keys
 
@@ -242,23 +196,17 @@ normalizeKeystroke = (keystroke) ->
       else
         return false
 
-  if isKeyup
-    primaryKey = primaryKey.toLowerCase() if primaryKey?
-  else
-    modifiers.add('shift') if UpperCaseLetterRegex.test(primaryKey)
-    if modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
-      primaryKey = primaryKey.toUpperCase()
+  modifiers.add('shift') if UpperCaseLetterRegex.test(primaryKey)
+  if modifiers.has('shift') and LowerCaseLetterRegex.test(primaryKey)
+    primaryKey = primaryKey.toUpperCase()
 
   keystroke = []
-  if not isKeyup or (isKeyup and not primaryKey?)
-    keystroke.push('ctrl') if modifiers.has('ctrl')
-    keystroke.push('alt') if modifiers.has('alt')
-    keystroke.push('shift') if modifiers.has('shift')
-    keystroke.push('cmd') if modifiers.has('cmd')
+  keystroke.push('ctrl') if modifiers.has('ctrl')
+  keystroke.push('alt') if modifiers.has('alt')
+  keystroke.push('shift') if modifiers.has('shift')
+  keystroke.push('cmd') if modifiers.has('cmd')
   keystroke.push(primaryKey) if primaryKey?
-  keystroke = keystroke.join('-')
-  keystroke = "^#{keystroke}" if isKeyup
-  keystroke
+  keystroke.join('-')
 
 parseKeystroke = (keystroke) ->
   keys = []
@@ -278,7 +226,7 @@ keyForKeyboardEvent = (event, dvorakQwertyWorkaroundEnabled) ->
   if process.platform in ['linux', 'win32']
     keyIdentifier = translateKeyIdentifierForWindowsAndLinuxChromiumBug(keyIdentifier)
 
-  return keyIdentifier if KeyboardEventModifiers.has(keyIdentifier)
+  return null if KeyboardEventModifiers.has(keyIdentifier)
 
   charCode = charCodeFromKeyIdentifier(keyIdentifier)
 

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -7,8 +7,7 @@ class KeyBinding
   enabled: true
 
   constructor: (@source, @command, @keystrokes, selector, @priority) ->
-    @keystrokeArray = @keystrokes.split(' ')
-    @keystrokeCount = @keystrokeArray.length
+    @keystrokeCount = @keystrokes.split(' ').length
     @selector = selector.replace(/!important/g, '')
     @specificity = calculateSpecificity(selector)
     @index = @constructor.currentIndex++


### PR DESCRIPTION
Reverts atom/atom-keymap#113

Dammit, well, if there is any keydown keybinding that is a partial match, it waits for the timeout before running the command. So when binding to `ctrl-tab ^ctrl`, every time you press `ctrl-tab` it will wait for the timeout. If you have a binding like `a c ^c ^a`, you basically cant type `a` in an editor. It’ll wait for the timeout which is long, _then_ put the `a` in there.