### PR TITLE
Run exact matches when the remainder of the partially matched commands are only keyup events

### DIFF
--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -54,3 +54,6 @@ describe ".keystrokesMatch(bindingKeystrokes, userKeystrokes)", ->
     expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b'])).toBe 'partial'
     expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b'])).toBe 'partial'
     expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'd', '^d'])).toBe false
+
+  it "returns 'keydownExact' for bindings that match and contain a remainder of only keyup events", ->
+    expect(keystrokesMatch(['a', 'b', '^b'], ['a', 'b'])).toBe 'keydownExact'

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -36,19 +36,23 @@ describe ".keystrokesMatch(bindingKeystrokes, userKeystrokes)", ->
   it "returns 'exact' for exact matches", ->
     expect(keystrokesMatch(['ctrl-tab', '^tab', '^ctrl'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
     expect(keystrokesMatch(['ctrl-tab', '^ctrl'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
-    expect(keystrokesMatch(['ctrl-tab', '^tab'], ['ctrl-tab', '^tab', '^ctrl'])).toBe 'exact'
-
-    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe 'exact'
-    expect(keystrokesMatch(['a', 'b', '^b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe 'exact'
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b', 'c'])).toBe 'exact'
+    expect(keystrokesMatch(['a', 'b', '^b', 'c'], ['a', '^a', 'b', '^b', 'c'])).toBe 'exact'
 
   it "returns false for non-matches", ->
+    expect(keystrokesMatch(['ctrl-tab', '^tab'], ['ctrl-tab', '^tab', '^ctrl'])).toBe false
+    expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+    expect(keystrokesMatch(['a', 'b', '^b', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+
     expect(keystrokesMatch(['a'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
+    expect(keystrokesMatch(['a'], ['a', '^a'])).toBe false
     expect(keystrokesMatch(['a', 'c'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
     expect(keystrokesMatch(['a', 'b', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
     expect(keystrokesMatch(['a', 'd', '^d'], ['a', '^a', 'b', '^b', 'c', '^c'])).toBe false
     expect(keystrokesMatch(['a', 'd', '^d'], ['^c'])).toBe false
 
   it "returns 'partial' for partial matches", ->
+    expect(keystrokesMatch(['a', 'b', '^b'], ['a'])).toBe 'partial'
     expect(keystrokesMatch(['a', 'b', 'c'], ['a'])).toBe 'partial'
     expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a'])).toBe 'partial'
     expect(keystrokesMatch(['a', 'b', 'c'], ['a', '^a', 'b'])).toBe 'partial'

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -271,14 +271,18 @@ describe "KeymapManager", ->
 
           events = []
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('v', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('i', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('i', target: editor))
           expect(events).toEqual []
           advanceClock(keymapManager.getPartialMatchTimeout())
           expect(events).toEqual ['enter-visual-mode', 'input:i']
 
           events = []
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('v', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('i', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('i', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('v', target: editor))
           expect(events).toEqual []
           advanceClock(keymapManager.getPartialMatchTimeout())

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -363,7 +363,6 @@ describe "KeymapManager", ->
             "ctrl-y ^ctrl": "y-command-ctrl-up"
             "ctrl-x ^ctrl": "x-command-ctrl-up"
             "ctrl-y ^y ^ctrl": "y-command-y-up-ctrl-up"
-            "a": "a-command"
             "a b c ^b ^a ^c": "abc-secret-code-command"
 
       it "dispatches the command for a binding containing only keydown events immediately even when there is a corresponding multi-stroke binding that contains only other keyup events", ->
@@ -431,15 +430,6 @@ describe "KeymapManager", ->
         keymapManager.handleKeyboardEvent(buildKeyupEvent('c', target: elementA))
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['abc-secret-code']
-
-      it "dispatches the command when multiple keyup keystrokes are specified", ->
-        keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: elementA))
-        keymapManager.handleKeyboardEvent(buildKeyupEvent('a', target: elementA))
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        advanceClock(keymapManager.getPartialMatchTimeout())
-        expect(events).toEqual []
 
     it "only counts entire keystrokes when checking for partial matches", ->
       element = $$ -> @div class: 'a'

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -378,7 +378,7 @@ describe "KeymapManager", ->
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-keydown', 'y-up-ctrl-keyup']
 
-      it "dispatches the command multiple times when keydown is pressed", ->
+      it "dispatches the command multiple times when multiple keydown events for the binding come in before the binding with a keyup handler", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         expect(events).toEqual ['y-keydown']
         keymapManager.handleKeyboardEvent(buildKeyupEvent('y', ctrl: true, target: elementA))
@@ -388,7 +388,7 @@ describe "KeymapManager", ->
         advanceClock(keymapManager.getPartialMatchTimeout())
         expect(events).toEqual ['y-keydown', 'y-keydown']
 
-      it "dispatches the command when modifier is lifted before the character", ->
+      it "dispatches the command when the modifier is lifted before the character", ->
         keymapManager.handleKeyboardEvent(buildKeydownEvent('y', ctrl: true, target: elementA))
         expect(events).toEqual ['y-keydown']
         keymapManager.handleKeyboardEvent(buildKeyupEvent('ctrl', target: elementA))

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -224,6 +224,10 @@ exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
     if isPartialMatch
       bindingRemainderContainsOnlyKeyups = false unless bindingKeystroke.startsWith('^')
 
+  # Bindings that match the beginning of the user's keystrokes are not a match.
+  # e.g. This is not a match. It would have been a match on the previous keystroke:
+  # bindingKeystrokes = ['ctrl-tab', '^tab']
+  # userKeystrokes    = ['ctrl-tab', '^tab', '^ctrl']
   return false if userKeystrokeIndex < userKeystrokes.length - 1
 
   if isPartialMatch and bindingRemainderContainsOnlyKeyups

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -224,10 +224,7 @@ exports.keystrokesMatch = (bindingKeystrokes, userKeystrokes) ->
     if isPartialMatch
       bindingRemainderContainsOnlyKeyups = false unless bindingKeystroke.startsWith('^')
 
-  # Prevent binding of ['a'] from exact matching a user pattern of ['a', '^a', 'b', '^b']
-  while userKeystrokeIndex < userKeystrokes.length - 1
-    userKeystrokeIndex += 1
-    return false unless userKeystrokes[userKeystrokeIndex].startsWith('^')
+  return false if userKeystrokeIndex < userKeystrokes.length - 1
 
   if isPartialMatch and bindingRemainderContainsOnlyKeyups
     KeydownExactMatch

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -435,15 +435,15 @@ class KeymapManager
     # // The binding: 'ctrl-a b c': 'my-sweet-command'
     # @queuedKeystrokes = ['ctrl-a', 'b'] // The user's keystrokes
     #
-    # When it finds partially matching bindings, it will set the keymap into a
-    # pending state via `enterPendingState`.
+    # When it finds partially matching bindings, it will set the KeymapManager
+    # into a pending state via `enterPendingState`.
     #
     # If a keystroke comes in that either matches a binding exactly, or yields
     # no partial matches, we will reset the state variables and exit pending
     # mode. If the keystroke yields no partial matches we will call
     # `terminatePendingState`
     #
-    # // Both of these will kick out of : 'ctrl-a b c': 'my-sweet-command'
+    # // Both of these will exit pending state for: 'ctrl-a b c': 'my-sweet-command'
     # @queuedKeystrokes = ['ctrl-a', 'b', 'c'] // Exact match! Just clear the state variables. Easy.
     # @queuedKeystrokes = ['ctrl-a', 'b', 'd'] // No hope of matching, terminatePendingState(). Dragons.
     #
@@ -457,7 +457,7 @@ class KeymapManager
     # 'b d': 'do-a-bd-deal'
     # 'd o g': 'wag-the-dog'
     #
-    # With these example commands, and the user's keystrokes, we should dispatch
+    # With these example bindings, and the user's keystrokes, we should dispatch
     # commands `ctrl-a-command` and `do-a-bd-deal`.
     #
     # To enable this behavior, `terminatePendingState` will _disable_ the
@@ -474,8 +474,8 @@ class KeymapManager
     # `terminatePendingState`. The 2nd call to `terminatePendingState` might
     # disable other bindings, and do another replay, which might call this
     # function again ... and on and on. It will recurse until the KeymapManager
-    # is no longer in a pending state with no partial matches on the most recent
-    # event.
+    # is no longer in a pending state with no partial matches from the most
+    # recent event.
     #
     # Godspeed.
 

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -626,6 +626,13 @@ class KeymapManager
   # It disables the longest of the pending partially matching bindings, then
   # replays the queued keyboard events to allow any bindings with shorter
   # keystroke sequences to be matched unambiguously.
+  #
+  # Note that replaying events has a recursive behavior. Replaying will set
+  # member state (e.g. @queuedKeyboardEvents) just like real events, and will
+  # likely result in another call this function. The replay process will
+  # potentially replay the events (or a subset of events) several times, while
+  # disabling bindings here and there. See any spec that handles multiple
+  # keystrokes failures to match a binding.
   terminatePendingState: (fromTimeout) ->
     bindingsToDisable = @pendingPartialMatches
     eventsToReplay = @queuedKeyboardEvents

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -604,12 +604,19 @@ class KeymapManager
     @cancelPendingState()
     @clearQueuedKeystrokes()
 
-    binding.enabled = false for binding in bindingsToDisable
+    enableBindings = (bindings) ->
+      if bindings?
+        binding.enabled = true for binding in bindings
 
+    disableBindings = (bindings) ->
+      if bindings?
+        binding.enabled = false for binding in bindings
+
+    disableBindings(bindingsToDisable)
     for event in eventsToReplay
-      @handleKeyboardEvent(event)
+      @handleKeyboardEvent(event, true)
       if bindingsToDisable? and not @pendingPartialMatches?
-        binding.enabled = true for binding in bindingsToDisable
+        enableBindings(bindingsToDisable)
         bindingsToDisable = null
 
     atom?.assert(not bindingsToDisable?, "Invalid keymap state")

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -647,8 +647,6 @@ class KeymapManager
         binding.enabled = true for binding in bindingsToDisable
         bindingsToDisable = null
 
-    atom?.assert(not bindingsToDisable?, "Invalid keymap state")
-
     binding.enabled = true for binding in bindingsToDisable if bindingsToDisable?
 
     if fromTimeout and @pendingPartialMatches?

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -419,15 +419,14 @@ class KeymapManager
     @queuedKeystrokes.push(keystroke)
     @queuedKeyboardEvents.push(event)
 
-    if queuedKeystrokes?
-      if hasPartialMatches
-        enableTimeout = (
-          @pendingStateTimeoutHandle? or
-          exactMatch? or
-          characterForKeyboardEvent(@queuedKeyboardEvents[0])?
-        )
-        enableTimeout = false if isReplay
-        @enterPendingState(partialMatches, enableTimeout)
+    if queuedKeystrokes? and hasPartialMatches
+      enableTimeout = (
+        @pendingStateTimeoutHandle? or
+        exactMatch? or
+        characterForKeyboardEvent(@queuedKeyboardEvents[0])?
+      )
+      enableTimeout = false if isReplay
+      @enterPendingState(partialMatches, enableTimeout)
     else if not exactMatch? and not hasPartialMatches and @pendingPartialMatches?
       @terminatePendingState()
     else

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -519,7 +519,7 @@ class KeymapManager
       # whose default action was prevented and no binding is matched, we'll
       # simulate the text input event that was previously prevented to insert
       # the missing characters.
-      @simulateTextInput(event) if event.defaultPrevented
+      @simulateTextInput(event) if event.defaultPrevented and event.type is 'keydown'
       queuedKeystrokes = null
 
     return {keystroke, exactMatch, partialMatches, queuedKeystrokes}

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -640,19 +640,11 @@ class KeymapManager
     @cancelPendingState()
     @clearQueuedKeystrokes()
 
-    enableBindings = (bindings) ->
-      if bindings?
-        binding.enabled = true for binding in bindings
-
-    disableBindings = (bindings) ->
-      if bindings?
-        binding.enabled = false for binding in bindings
-
-    disableBindings(bindingsToDisable)
+    binding.enabled = false for binding in bindingsToDisable if bindingsToDisable?
     for event in eventsToReplay
       @handleKeyboardEvent(event, true)
       if bindingsToDisable? and not @pendingPartialMatches?
-        enableBindings(bindingsToDisable)
+        binding.enabled = true for binding in bindingsToDisable if bindingsToDisable?
         bindingsToDisable = null
 
     atom?.assert(not bindingsToDisable?, "Invalid keymap state")

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -640,11 +640,11 @@ class KeymapManager
     @cancelPendingState()
     @clearQueuedKeystrokes()
 
-    binding.enabled = false for binding in bindingsToDisable if bindingsToDisable?
+    binding.enabled = false for binding in bindingsToDisable
     for event in eventsToReplay
       @handleKeyboardEvent(event, true)
       if bindingsToDisable? and not @pendingPartialMatches?
-        binding.enabled = true for binding in bindingsToDisable if bindingsToDisable?
+        binding.enabled = true for binding in bindingsToDisable
         bindingsToDisable = null
 
     atom?.assert(not bindingsToDisable?, "Invalid keymap state")

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -626,7 +626,7 @@ class KeymapManager
   # It disables the longest of the pending partially matching bindings, then
   # replays the queued keyboard events to allow any bindings with shorter
   # keystroke sequences to be matched unambiguously.
-  terminatePendingState: (timeout) ->
+  terminatePendingState: (fromTimeout) ->
     bindingsToDisable = @pendingPartialMatches
     eventsToReplay = @queuedKeyboardEvents
 
@@ -650,7 +650,7 @@ class KeymapManager
 
     atom?.assert(not bindingsToDisable?, "Invalid keymap state")
 
-    if timeout and @pendingPartialMatches?
+    if fromTimeout and @pendingPartialMatches?
       @terminatePendingState(true)
 
     return

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -486,7 +486,6 @@ class KeymapManager
             queuedKeystrokes = null
 
           if @dispatchCommandEvent(exactMatchCandidate.command, target, event)
-            console.log '..dispatching', keystrokes
             @emitter.emit 'did-match-binding', {
               keystrokes,
               eventType: event.type,
@@ -523,7 +522,6 @@ class KeymapManager
       # the missing characters.
       if event.defaultPrevented
         @simulateTextInput(event)
-        console.log 'simulate', keystroke
       queuedKeystrokes = null
 
     return {keystroke, exactMatch, partialMatches, queuedKeystrokes}

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -414,7 +414,7 @@ class KeymapManager
     # Handling keyboard events is complicated and very nuanced. The
     # complexity is all because of multi-stroke bindings. For example:
     #
-    # 'ctrl-a b c': 'my-sweet-command'
+    # 'ctrl-a b c': 'my-sweet-command' // This is a binding
     #
     # This example means the user can type `ctrl-a` then `b` then `c`, and after
     # all of those keys are typed, it will dispatch the `my-sweet-command`

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -422,19 +422,18 @@ class KeymapManager
     #
     # The KeymapManager has a couple member variables to deal with multi-stroke
     # bindings: `@queuedKeystrokes` and `@queuedKeyboardEvents`. They keep track
-    # of the keystrokes the user has typed, and every call to this function will
-    # try to match the user's keystrokes against bindings loaded in this object.
-    # When populated, the state variables look something like
+    # of the keystrokes the user has typed. When populated, the state variables
+    # look something like:
     #
     # @queuedKeystrokes = ['ctrl-a', 'b', 'c']
     # @queuedKeyboardEvents = [KeyboardEvent, KeyboardEvent, KeyboardEvent]
     #
-    # Basically, this method will try to exactly match the user's keystrokes to
-    # a binding. If it cant match exactly, it looks for partial matches. A
-    # partial match might be something like:
+    # Basically, this `handleKeyboardEvent` function will try to exactly match
+    # the user's keystrokes to a binding. If it cant match exactly, it looks for
+    # partial matches. A partial match might be something like:
     #
     # // The binding: 'ctrl-a b c': 'my-sweet-command'
-    # @queuedKeystrokes = ['ctrl-a', 'b']
+    # @queuedKeystrokes = ['ctrl-a', 'b'] // The user's keystrokes
     #
     # When it finds partially matching bindings, it will set the keymap into a
     # pending state via `enterPendingState`.
@@ -445,8 +444,8 @@ class KeymapManager
     # `terminatePendingState`
     #
     # // Both of these will kick out of : 'ctrl-a b c': 'my-sweet-command'
-    # @queuedKeystrokes = ['ctrl-a', 'b', 'c'] // Exact match!
-    # @queuedKeystrokes = ['ctrl-a', 'b', 'd'] // No hope of matching, terminatePendingState()
+    # @queuedKeystrokes = ['ctrl-a', 'b', 'c'] // Exact match! Just clear the state variables. Easy.
+    # @queuedKeystrokes = ['ctrl-a', 'b', 'd'] // No hope of matching, terminatePendingState(). Dragons.
     #
     # `terminatePendingState` is where things get crazy. Let's pretend the user
     # typed `['ctrl-a', 'b', 'd']`. There are were no exact matches from this

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -649,6 +649,8 @@ class KeymapManager
 
     atom?.assert(not bindingsToDisable?, "Invalid keymap state")
 
+    binding.enabled = true for binding in bindingsToDisable if bindingsToDisable?
+
     if fromTimeout and @pendingPartialMatches?
       @terminatePendingState(true)
 

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -519,8 +519,7 @@ class KeymapManager
       # whose default action was prevented and no binding is matched, we'll
       # simulate the text input event that was previously prevented to insert
       # the missing characters.
-      if event.defaultPrevented
-        @simulateTextInput(event)
+      @simulateTextInput(event) if event.defaultPrevented
       queuedKeystrokes = null
 
     return {keystroke, exactMatch, partialMatches, queuedKeystrokes}

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -478,6 +478,9 @@ class KeymapManager
 
           exactMatch = exactMatchCandidate
           if partialMatches.length > 0
+            # When there is a set of bindings like `'ctrl-y', 'ctrl-y ^ctrl'`,
+            # and a `ctrl-y` comes in, this will allow the `ctrl-y` command to be
+            # dispatched without waiting for any other keystrokes
             allPartialMatchesContainKeyupRemainder = true
             for partialMatch in partialMatches
               if keydownExactMatchCandidates.indexOf(partialMatch) < 0
@@ -493,7 +496,7 @@ class KeymapManager
               binding: exactMatchCandidate,
               keyboardEventTarget: target
             }
-            event.handled = true
+            event.handled = true # Kicks it out of the parent loop
             break
         currentTarget = currentTarget.parentElement
 

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -432,6 +432,8 @@ class KeymapManager
     else
       @clearQueuedKeystrokes()
 
+  # This function does not set any state. State is handled in the
+  # `handleKeyboardEvent` function.
   _handleKeyboardEvent: (event, queuedKeystrokes=[]) ->
     keystroke = @keystrokeForKeyboardEvent(event)
 

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -527,7 +527,7 @@ class KeymapManager
       @simulateTextInput(event) if event.defaultPrevented and event.type is 'keydown'
       queuedKeystrokes = null
 
-    return {keystroke, exactMatch, partialMatches, queuedKeystrokes}
+    {keystroke, exactMatch, partialMatches, queuedKeystrokes}
 
 
   # Public: Translate a keydown event to a keystroke string.


### PR DESCRIPTION
Basically this adds the concept of a `KeydownExact` match. That is, if there are bindings like

```coffee
'atom-workspace':
  'ctrl-y': 'core:do-down'
  'ctrl-y ^ctrl': 'core:do-up'
```

It will run the `core:do-down` command immediately when seeing the `ctrl-y` keystroke because all the matched partial bindings (in this case `'ctrl-y ^ctrl'`) have only keyup keystrokes in the unmached portion of the binding. Previous to this change, it would need to wait for a timeout or something to break the partial bindings to run the initial command.

The diff looks crazy because I split the `handleKeyupEvent()` out into two functions: `handleKeyupEvent` and `_handleKeyupEvent`. The former deals with setting object state, and the latter does not. I was adding a bunch of complexity in various parts of the original function, and this made things much more clear. We can rename the `_handleKeyupEvent` as I'm sure @nathansobo is not into it.

cc @natalieogle
