### PR TITLE
Fix stack level overflow when matching multiple prefixes of sequence bindings

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -211,7 +211,14 @@ describe "KeymapManager", ->
             'd o g': 'dog'
             'v i v a': 'viva!'
             'v i v': 'viv'
-          '.editor': 'v': 'enter-visual-mode'
+          '.editor':
+            'v': 'enter-visual-mode'
+            'space': 'move-right'
+            'space r r': 'command1'
+            'space r p': 'something-else'
+            'space a': 'something-else'
+            'r': 'vim-mode-replace'
+
           '.editor.visual-mode': 'i w': 'select-inside-word'
 
         events = []
@@ -221,6 +228,21 @@ describe "KeymapManager", ->
         workspace.addEventListener 'viv', -> events.push('viv')
         workspace.addEventListener 'select-inside-word', -> events.push('select-inside-word')
         workspace.addEventListener 'enter-visual-mode', -> events.push('enter-visual-mode'); editor.classList.add('visual-mode')
+        workspace.addEventListener 'vim-mode-replace', -> events.push('vim-mode-replace');
+        workspace.addEventListener 'move-right', -> events.push('move-right');
+        workspace.addEventListener 'command1', -> events.push('command1');
+
+      describe "when keystrokes match a series of commands", ->
+        it "matches the correct actions", ->
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('space', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('space', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('r', target: editor))
+          keymapManager.handleKeyboardEvent(buildKeyupEvent('r', target: editor))
+          keymapManager.handleKeyboardEvent(a = buildKeydownEvent('a', target: editor))
+          expect(clearTimeout).toHaveBeenCalled()
+          expect(a.defaultPrevented).toBe false
+          expect(events).toEqual ['move-right', 'vim-mode-replace']
+
 
       describe "when subsequent keystrokes yield an exact match", ->
         it "dispatches the command associated with the matched multi-keystroke binding", ->

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -213,12 +213,8 @@ describe "KeymapManager", ->
             'v i v': 'viv'
           '.editor':
             'v': 'enter-visual-mode'
-            'space': 'move-right'
             'space r r': 'command1'
-            'space r p': 'something-else'
-            'space a': 'something-else'
-            'r': 'vim-mode-replace'
-
+            'space b': 'something-else'
           '.editor.visual-mode': 'i w': 'select-inside-word'
 
         events = []
@@ -228,9 +224,6 @@ describe "KeymapManager", ->
         workspace.addEventListener 'viv', -> events.push('viv')
         workspace.addEventListener 'select-inside-word', -> events.push('select-inside-word')
         workspace.addEventListener 'enter-visual-mode', -> events.push('enter-visual-mode'); editor.classList.add('visual-mode')
-        workspace.addEventListener 'vim-mode-replace', -> events.push('vim-mode-replace');
-        workspace.addEventListener 'move-right', -> events.push('move-right');
-        workspace.addEventListener 'command1', -> events.push('command1');
 
       describe "when keystrokes match a series of commands", ->
         it "matches the correct actions", ->
@@ -238,11 +231,8 @@ describe "KeymapManager", ->
           keymapManager.handleKeyboardEvent(buildKeyupEvent('space', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('r', target: editor))
           keymapManager.handleKeyboardEvent(buildKeyupEvent('r', target: editor))
-          keymapManager.handleKeyboardEvent(a = buildKeydownEvent('a', target: editor))
-          expect(clearTimeout).toHaveBeenCalled()
-          expect(a.defaultPrevented).toBe false
-          expect(events).toEqual ['move-right', 'vim-mode-replace']
-
+          keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: editor))
+          # expect this to not raise a gnarly stack level too deep exception
 
       describe "when subsequent keystrokes yield an exact match", ->
         it "dispatches the command associated with the matched multi-keystroke binding", ->

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -228,9 +228,7 @@ describe "KeymapManager", ->
       describe "when keystrokes match a series of commands", ->
         it "matches the correct actions", ->
           keymapManager.handleKeyboardEvent(buildKeydownEvent('space', target: editor))
-          keymapManager.handleKeyboardEvent(buildKeyupEvent('space', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('r', target: editor))
-          keymapManager.handleKeyboardEvent(buildKeyupEvent('r', target: editor))
           keymapManager.handleKeyboardEvent(buildKeydownEvent('a', target: editor))
           # expect this to not raise a gnarly stack level too deep exception
 


### PR DESCRIPTION
This spec fails with a recursing stack level exception without the fix code.

I think it matches the failures being investigated at https://github.com/atom/atom/issues/11203

The fix is to maintain the disabled bindings between replays and only clear them explicitly when we've finished matching.

**NB:** I'm not sure this is a good fix. I haven't deeply considered if it might cause issues if for example there are bindings for `a a b c` and `a b` and `a a` and the user types `a a a b` and expects to get the commands for `a a` followed by `a b`. It might be ok because when `a a` matches it will clear the disabled binding of `a b`... or something. 

Might need some more specs to try to break it subsequent to this fix.

