### PR TITLE
Disable previously-failed partial matches during keystroke replay

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -209,6 +209,7 @@ describe "KeymapManager", ->
         keymapManager.add 'test',
           '.workspace':
             'd o g': 'dog'
+            'd p': 'dp'
             'v i v a': 'viva!'
             'v i v': 'viv'
           '.editor': 'v': 'enter-visual-mode'
@@ -217,6 +218,7 @@ describe "KeymapManager", ->
         events = []
         editor.addEventListener 'textInput', (event) -> events.push("input:#{event.data}")
         workspace.addEventListener 'dog', -> events.push('dog')
+        workspace.addEventListener 'dp', -> events.push('dp')
         workspace.addEventListener 'viva!', -> events.push('viva!')
         workspace.addEventListener 'viv', -> events.push('viv')
         workspace.addEventListener 'select-inside-word', -> events.push('select-inside-word')

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -512,6 +512,15 @@ class KeymapManager
     {partialMatchCandidates, keydownExactMatchCandidates, exactMatchCandidates} = @findMatchCandidates(@queuedKeystrokes, disabledBindings)
     dispatchedExactMatch = null
     partialMatches = @findPartialMatches(partialMatchCandidates, target)
+
+    # If any partial match *was* pending but has now failed to match, add it to
+    # the list of bindings to disable so we don't attempt to match it again
+    # during a subsequent event replay by `terminatePendingState`.
+    if @pendingPartialMatches?
+      liveMatches = new Set(partialMatches.concat(exactMatchCandidates))
+      for binding in @pendingPartialMatches
+        @bindingsToDisable.push(binding) unless liveMatches.has(binding)
+
     hasPartialMatches = partialMatches.length > 0
     shouldUsePartialMatches = hasPartialMatches
 


### PR DESCRIPTION
Fixes atom/atom#11203

@jackcasey I picked up where your PR left off but incorporated your commit. Thanks a *ton* for finding that test case. You saved me a lot of time tracking this down.

Can you try to break this in development mode? I'd like to hotfix beta and stable but I'm worried about introducing some other bug, and I actually have a pretty simple bindings setup on my own machine.

This is a quick fix, but really I'd like to find a solution that doesn't involve keystroke replay and reifies more of the ideas involved in matching as objects.