### PR TITLE
Always favor AltGraph variants on Windows

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -630,15 +630,15 @@ describe "KeymapManager", ->
         # Does not use alt variant character if ctrl modifier is used
         assert.equal(keymapManager.keystrokeForKeyboardEvent({key: '@', code: 'KeyG', ctrlKey: true, altKey: true}), 'ctrl-alt-g')
 
-      it "allows ASCII characters to be typed via an altgraph modifier on Windows", ->
+      it "allows any AltGraph-modified character to be typed via the ctrl-alt- modifiers on Windows", ->
         mockProcessPlatform('win32')
 
         currentKeymap = require('./helpers/keymaps/windows-swiss-german')
         assert.equal(keymapManager.keystrokeForKeyboardEvent({key: '@', code: 'Digit2', ctrlKey: true, altKey: true}), '@')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: '°', code: 'Digit4', ctrlKey: true, altKey: true}), 'ctrl-alt-4')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: '°', code: 'Digit4', ctrlKey: true, altKey: true}), '°')
 
         currentKeymap = require('./helpers/keymaps/windows-us-international')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: '¢', code: 'KeyC', ctrlKey: true, altKey: true, shiftKey: true}), 'ctrl-alt-shift-C')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: '¢', code: 'KeyC', ctrlKey: true, altKey: true, shiftKey: true}), '¢')
 
       it "allows arbitrary characters to be typed via an altgraph modifier on Linux", ->
         mockProcessPlatform('linux')


### PR DESCRIPTION
Unlike macOS, Windows doesn't always have an AltGraph variant for every key in every layout. So when one does exist, users really expect for it to work. When a conflicting ctrl-alt- binding exists, it won't be possible to use it and the user will need to create a new binding.