### PR TITLE
Translate dead keys to correct keystroke strings on Mac and Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.0.4",
     "grim": "^1.2.1",
-    "keyboard-layout": "^1.2.0",
+    "keyboard-layout": "^1.2.2",
     "pathwatcher": "^6.2",
     "property-accessors": "^1",
     "season": "^5.0.2"

--- a/spec/helpers/keymaps/mac-swedish.json
+++ b/spec/helpers/keymaps/mac-swedish.json
@@ -1,0 +1,398 @@
+{
+  "KeyA": {
+    "unmodified": "a",
+    "withShift": "A",
+    "withAltGraph": "",
+    "withAltGraphShift": "◊"
+  },
+  "KeyB": {
+    "unmodified": "b",
+    "withShift": "B",
+    "withAltGraph": "›",
+    "withAltGraphShift": "»"
+  },
+  "KeyC": {
+    "unmodified": "c",
+    "withShift": "C",
+    "withAltGraph": "ç",
+    "withAltGraphShift": "Ç"
+  },
+  "KeyD": {
+    "unmodified": "d",
+    "withShift": "D",
+    "withAltGraph": "∂",
+    "withAltGraphShift": "∆"
+  },
+  "KeyE": {
+    "unmodified": "e",
+    "withShift": "E",
+    "withAltGraph": "é",
+    "withAltGraphShift": "É"
+  },
+  "KeyF": {
+    "unmodified": "f",
+    "withShift": "F",
+    "withAltGraph": "ƒ",
+    "withAltGraphShift": "∫"
+  },
+  "KeyG": {
+    "unmodified": "g",
+    "withShift": "G",
+    "withAltGraph": "¸",
+    "withAltGraphShift": "¯"
+  },
+  "KeyH": {
+    "unmodified": "h",
+    "withShift": "H",
+    "withAltGraph": "˛",
+    "withAltGraphShift": "˘"
+  },
+  "KeyI": {
+    "unmodified": "i",
+    "withShift": "I",
+    "withAltGraph": "ı",
+    "withAltGraphShift": "ˆ"
+  },
+  "KeyJ": {
+    "unmodified": "j",
+    "withShift": "J",
+    "withAltGraph": "√",
+    "withAltGraphShift": "¬"
+  },
+  "KeyK": {
+    "unmodified": "k",
+    "withShift": "K",
+    "withAltGraph": "ª",
+    "withAltGraphShift": "º"
+  },
+  "KeyL": {
+    "unmodified": "l",
+    "withShift": "L",
+    "withAltGraph": "ﬁ",
+    "withAltGraphShift": "ﬂ"
+  },
+  "KeyM": {
+    "unmodified": "m",
+    "withShift": "M",
+    "withAltGraph": "’",
+    "withAltGraphShift": "”"
+  },
+  "KeyN": {
+    "unmodified": "n",
+    "withShift": "N",
+    "withAltGraph": "‘",
+    "withAltGraphShift": "“"
+  },
+  "KeyO": {
+    "unmodified": "o",
+    "withShift": "O",
+    "withAltGraph": "œ",
+    "withAltGraphShift": "Œ"
+  },
+  "KeyP": {
+    "unmodified": "p",
+    "withShift": "P",
+    "withAltGraph": "π",
+    "withAltGraphShift": "∏"
+  },
+  "KeyQ": {
+    "unmodified": "q",
+    "withShift": "Q",
+    "withAltGraph": "•",
+    "withAltGraphShift": "°"
+  },
+  "KeyR": {
+    "unmodified": "r",
+    "withShift": "R",
+    "withAltGraph": "®",
+    "withAltGraphShift": "√"
+  },
+  "KeyS": {
+    "unmodified": "s",
+    "withShift": "S",
+    "withAltGraph": "ß",
+    "withAltGraphShift": "∑"
+  },
+  "KeyT": {
+    "unmodified": "t",
+    "withShift": "T",
+    "withAltGraph": "†",
+    "withAltGraphShift": "‡"
+  },
+  "KeyU": {
+    "unmodified": "u",
+    "withShift": "U",
+    "withAltGraph": "ü",
+    "withAltGraphShift": "Ü"
+  },
+  "KeyV": {
+    "unmodified": "v",
+    "withShift": "V",
+    "withAltGraph": "‹",
+    "withAltGraphShift": "«"
+  },
+  "KeyW": {
+    "unmodified": "w",
+    "withShift": "W",
+    "withAltGraph": "Ω",
+    "withAltGraphShift": "˝"
+  },
+  "KeyX": {
+    "unmodified": "x",
+    "withShift": "X",
+    "withAltGraph": "≈",
+    "withAltGraphShift": "ˇ"
+  },
+  "KeyY": {
+    "unmodified": "y",
+    "withShift": "Y",
+    "withAltGraph": "µ",
+    "withAltGraphShift": "˜"
+  },
+  "KeyZ": {
+    "unmodified": "z",
+    "withShift": "Z",
+    "withAltGraph": "÷",
+    "withAltGraphShift": "⁄"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!",
+    "withAltGraph": "©",
+    "withAltGraphShift": "¡"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "\"",
+    "withAltGraph": "™",
+    "withAltGraphShift": "”"
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "#",
+    "withAltGraph": "£",
+    "withAltGraphShift": "¥"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "€",
+    "withAltGraph": "$",
+    "withAltGraphShift": "¢"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%",
+    "withAltGraph": "∞",
+    "withAltGraphShift": "‰"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "&",
+    "withAltGraph": "§",
+    "withAltGraphShift": "¶"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "/",
+    "withAltGraph": "|",
+    "withAltGraphShift": "\\"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "(",
+    "withAltGraph": "[",
+    "withAltGraphShift": "{"
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": ")",
+    "withAltGraph": "]",
+    "withAltGraphShift": "}"
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": "=",
+    "withAltGraph": "≈",
+    "withAltGraphShift": "≠"
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " ",
+    "withAltGraph": " ",
+    "withAltGraphShift": " "
+  },
+  "Minus": {
+    "unmodified": "+",
+    "withShift": "?",
+    "withAltGraph": "±",
+    "withAltGraphShift": "¿"
+  },
+  "Equal": {
+    "unmodified": "´",
+    "withShift": "`",
+    "withAltGraph": "´",
+    "withAltGraphShift": "`"
+  },
+  "BracketLeft": {
+    "unmodified": "å",
+    "withShift": "Å",
+    "withAltGraph": "˙",
+    "withAltGraphShift": "˚"
+  },
+  "BracketRight": {
+    "unmodified": "¨",
+    "withShift": "^",
+    "withAltGraph": "~",
+    "withAltGraphShift": "^"
+  },
+  "Backslash": {
+    "unmodified": "'",
+    "withShift": "*",
+    "withAltGraph": "@",
+    "withAltGraphShift": "’"
+  },
+  "Semicolon": {
+    "unmodified": "ö",
+    "withShift": "Ö",
+    "withAltGraph": "ø",
+    "withAltGraphShift": "Ø"
+  },
+  "Quote": {
+    "unmodified": "ä",
+    "withShift": "Ä",
+    "withAltGraph": "æ",
+    "withAltGraphShift": "Æ"
+  },
+  "Backquote": {
+    "unmodified": "<",
+    "withShift": ">",
+    "withAltGraph": "≤",
+    "withAltGraphShift": "≥"
+  },
+  "Comma": {
+    "unmodified": ",",
+    "withShift": ";",
+    "withAltGraph": "‚",
+    "withAltGraphShift": "„"
+  },
+  "Period": {
+    "unmodified": ".",
+    "withShift": ":",
+    "withAltGraph": "…",
+    "withAltGraphShift": "·"
+  },
+  "Slash": {
+    "unmodified": "-",
+    "withShift": "_",
+    "withAltGraph": "–",
+    "withAltGraphShift": "—"
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/",
+    "withAltGraph": "/",
+    "withAltGraphShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*",
+    "withAltGraph": "*",
+    "withAltGraphShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-",
+    "withAltGraph": "-",
+    "withAltGraphShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+",
+    "withAltGraph": "+",
+    "withAltGraphShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": "1",
+    "withShift": "1",
+    "withAltGraph": "1",
+    "withAltGraphShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": "2",
+    "withShift": "2",
+    "withAltGraph": "2",
+    "withAltGraphShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": "3",
+    "withShift": "3",
+    "withAltGraph": "3",
+    "withAltGraphShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": "4",
+    "withShift": "4",
+    "withAltGraph": "4",
+    "withAltGraphShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": "5",
+    "withShift": "5",
+    "withAltGraph": "5",
+    "withAltGraphShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": "6",
+    "withShift": "6",
+    "withAltGraph": "6",
+    "withAltGraphShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": "7",
+    "withShift": "7",
+    "withAltGraph": "7",
+    "withAltGraphShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": "8",
+    "withShift": "8",
+    "withAltGraph": "8",
+    "withAltGraphShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": "9",
+    "withShift": "9",
+    "withAltGraph": "9",
+    "withAltGraphShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": "0",
+    "withShift": "0",
+    "withAltGraph": "0",
+    "withAltGraphShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": ",",
+    "withShift": ".",
+    "withAltGraph": ",",
+    "withAltGraphShift": "."
+  },
+  "IntlBackslash": {
+    "unmodified": "§",
+    "withShift": "°",
+    "withAltGraph": "¶",
+    "withAltGraphShift": "•"
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "=",
+    "withAltGraph": "=",
+    "withAltGraphShift": "="
+  },
+  "AudioVolumeUp": {
+    "unmodified": null,
+    "withShift": "=",
+    "withAltGraph": null,
+    "withAltGraphShift": "="
+  }
+}

--- a/spec/helpers/keymaps/windows-swedish.json
+++ b/spec/helpers/keymaps/windows-swedish.json
@@ -1,0 +1,314 @@
+{
+  "KeyA": {
+    "unmodified": "a",
+    "withShift": "A",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyB": {
+    "unmodified": "b",
+    "withShift": "B",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyC": {
+    "unmodified": "c",
+    "withShift": "C",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyD": {
+    "unmodified": "d",
+    "withShift": "D",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyE": {
+    "unmodified": "e",
+    "withShift": "E",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyF": {
+    "unmodified": "f",
+    "withShift": "F",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyG": {
+    "unmodified": "g",
+    "withShift": "G",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyH": {
+    "unmodified": "h",
+    "withShift": "H",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyI": {
+    "unmodified": "i",
+    "withShift": "I",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyJ": {
+    "unmodified": "j",
+    "withShift": "J",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyK": {
+    "unmodified": "k",
+    "withShift": "K",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyL": {
+    "unmodified": "l",
+    "withShift": "L",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyM": {
+    "unmodified": "m",
+    "withShift": "M",
+    "withAltGraph": "µ",
+    "withAltGraphShift": null
+  },
+  "KeyN": {
+    "unmodified": "n",
+    "withShift": "N",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyO": {
+    "unmodified": "o",
+    "withShift": "O",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyP": {
+    "unmodified": "p",
+    "withShift": "P",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyQ": {
+    "unmodified": "q",
+    "withShift": "Q",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyR": {
+    "unmodified": "r",
+    "withShift": "R",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyS": {
+    "unmodified": "s",
+    "withShift": "S",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyT": {
+    "unmodified": "t",
+    "withShift": "T",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyU": {
+    "unmodified": "u",
+    "withShift": "U",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyV": {
+    "unmodified": "v",
+    "withShift": "V",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyW": {
+    "unmodified": "w",
+    "withShift": "W",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyX": {
+    "unmodified": "x",
+    "withShift": "X",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyY": {
+    "unmodified": "y",
+    "withShift": "Y",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyZ": {
+    "unmodified": "z",
+    "withShift": "Z",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "\"",
+    "withAltGraph": "@",
+    "withAltGraphShift": null
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "#",
+    "withAltGraph": "£",
+    "withAltGraphShift": null
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "¤",
+    "withAltGraph": "$",
+    "withAltGraphShift": null
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "&",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "/",
+    "withAltGraph": "{",
+    "withAltGraphShift": null
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "(",
+    "withAltGraph": "[",
+    "withAltGraphShift": null
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": ")",
+    "withAltGraph": "]",
+    "withAltGraphShift": null
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": "=",
+    "withAltGraph": "}",
+    "withAltGraphShift": null
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " ",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Minus": {
+    "unmodified": "+",
+    "withShift": "?",
+    "withAltGraph": "\\",
+    "withAltGraphShift": null
+  },
+  "Equal": {
+    "unmodified": "´",
+    "withShift": "`",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "BracketLeft": {
+    "unmodified": "å",
+    "withShift": "Å",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "BracketRight": {
+    "unmodified": "¨",
+    "withShift": "^",
+    "withAltGraph": "~",
+    "withAltGraphShift": null
+  },
+  "Backslash": {
+    "unmodified": "~'",
+    "withShift": "*",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Semicolon": {
+    "unmodified": "ö",
+    "withShift": "Ö",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Quote": {
+    "unmodified": "ä",
+    "withShift": "Ä",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Backquote": {
+    "unmodified": "§",
+    "withShift": "½",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Comma": {
+    "unmodified": ",",
+    "withShift": ";",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Period": {
+    "unmodified": ".",
+    "withShift": ":",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Slash": {
+    "unmodified": "-",
+    "withShift": "_",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "IntlBackslash": {
+    "unmodified": "<",
+    "withShift": ">",
+    "withAltGraph": "|",
+    "withAltGraphShift": null
+  }
+}

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -679,6 +679,19 @@ describe "KeymapManager", ->
         # Don't use U.S. counterpart for latin characters
         assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'ö', code: 'KeyX', metaKey: true}), 'cmd-ö')
 
+      it "translates dead keys to their printable equivalents", ->
+        mockProcessPlatform('darwin')
+        currentKeymap = require('./helpers/keymaps/mac-swedish')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'Dead', code: 'BracketRight'}), '¨')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'Dead', code: 'BracketRight', shiftKey: true}), '^')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'Dead', code: 'BracketRight', altKey: true}), '~')
+
+        mockProcessPlatform('win32')
+        currentKeymap = require('./helpers/keymaps/windows-swedish')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'Dead', code: 'BracketRight'}), '¨')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'Dead', code: 'BracketRight', shiftKey: true}), '^')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent({key: 'Dead', code: 'BracketRight', ctrlKey: true, altKey: true, shiftKey: true}), '~')
+
   describe "::findKeyBindings({command, target, keystrokes})", ->
     [elementA, elementB] = []
     beforeEach ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -95,14 +95,25 @@ parseKeystroke = (keystroke) ->
   keys
 
 exports.keystrokeForKeyboardEvent = (event) ->
-  {ctrlKey, altKey, shiftKey, metaKey} = event
-  isNonCharacterKey = event.key.length > 1
+  {key, ctrlKey, altKey, shiftKey, metaKey} = event
 
+  if key is 'Dead'
+    if process.platform isnt 'linux' and characters = KeyboardLayout.getCurrentKeymap()[event.code]
+      if ctrlKey and altKey and shiftKey and characters.withAltGraphShift?
+        key = characters.withAltGraphShift
+      else if process.platform is 'darwin' and altKey and characters.withAltGraph?
+        key = characters.withAltGraph
+      else if process.platform is 'win32' and ctrlKey and altKey and characters.withAltGraph?
+        key = characters.withAltGraph
+      else if shiftKey and characters.withShift?
+        key = characters.withShift
+      else if characters.unmodified?
+        key = characters.unmodified
+
+  isNonCharacterKey = key.length > 1
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[event.key] ? event.key.toLowerCase()
   else
-    key = event.key
-
     if altKey
       # All macOS layouts have an alt-modified character variant for every
       # single key. Therefore, if we always favored the alt variant, it would


### PR DESCRIPTION
This uses some new functionality in `KeyboardLayout` for harvesting the printable equivalent of dead keys.

To fully support translating dead keys to the correct keystroke strings on Linux, we'll need to add native support for it in KeyboardLayout there as well :tada:.