### PR TITLE
Fix keystroke resolution problems on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+    - libx11-dev
+    - libxkbfile-dev
 
 node_js:
   - "node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-keymap",
-  "version": "7.0.3",
+  "version": "7.0.4-beta0",
   "description": "Atom's DOM-aware keymap module",
   "main": "./lib/keymap-manager",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.0.4",
     "grim": "^1.2.1",
-    "keyboard-layout": "^1.2.2",
+    "keyboard-layout": "^1.3.0",
     "pathwatcher": "^6.2",
     "property-accessors": "^1",
     "season": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.0.4",
     "grim": "^1.2.1",
-    "keyboard-layout": "^1.3.0",
+    "keyboard-layout": "^2.0.0",
     "pathwatcher": "^6.2",
     "property-accessors": "^1",
     "season": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-keymap",
-  "version": "7.0.4-beta0",
+  "version": "7.0.6-beta0",
   "description": "Atom's DOM-aware keymap module",
   "main": "./lib/keymap-manager",
   "scripts": {

--- a/spec/helpers/keymaps/linux-dvorak.json
+++ b/spec/helpers/keymaps/linux-dvorak.json
@@ -1,0 +1,274 @@
+{
+  "KeyA": {
+    "unmodified": "a",
+    "withShift": "A"
+  },
+  "KeyB": {
+    "unmodified": "x",
+    "withShift": "X"
+  },
+  "KeyC": {
+    "unmodified": "j",
+    "withShift": "J"
+  },
+  "KeyD": {
+    "unmodified": "e",
+    "withShift": "E"
+  },
+  "KeyE": {
+    "unmodified": ".",
+    "withShift": ">"
+  },
+  "KeyF": {
+    "unmodified": "u",
+    "withShift": "U"
+  },
+  "KeyG": {
+    "unmodified": "i",
+    "withShift": "I"
+  },
+  "KeyH": {
+    "unmodified": "d",
+    "withShift": "D"
+  },
+  "KeyI": {
+    "unmodified": "c",
+    "withShift": "C"
+  },
+  "KeyJ": {
+    "unmodified": "h",
+    "withShift": "H"
+  },
+  "KeyK": {
+    "unmodified": "t",
+    "withShift": "T"
+  },
+  "KeyL": {
+    "unmodified": "n",
+    "withShift": "N"
+  },
+  "KeyM": {
+    "unmodified": "m",
+    "withShift": "M"
+  },
+  "KeyN": {
+    "unmodified": "b",
+    "withShift": "B"
+  },
+  "KeyO": {
+    "unmodified": "r",
+    "withShift": "R"
+  },
+  "KeyP": {
+    "unmodified": "l",
+    "withShift": "L"
+  },
+  "KeyQ": {
+    "unmodified": "'",
+    "withShift": "\""
+  },
+  "KeyR": {
+    "unmodified": "p",
+    "withShift": "P"
+  },
+  "KeyS": {
+    "unmodified": "o",
+    "withShift": "O"
+  },
+  "KeyT": {
+    "unmodified": "y",
+    "withShift": "Y"
+  },
+  "KeyU": {
+    "unmodified": "g",
+    "withShift": "G"
+  },
+  "KeyV": {
+    "unmodified": "k",
+    "withShift": "K"
+  },
+  "KeyW": {
+    "unmodified": ",",
+    "withShift": "<"
+  },
+  "KeyX": {
+    "unmodified": "q",
+    "withShift": "Q"
+  },
+  "KeyY": {
+    "unmodified": "f",
+    "withShift": "F"
+  },
+  "KeyZ": {
+    "unmodified": ";",
+    "withShift": ":"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "@"
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "#"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "$"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "^"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "&"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "*"
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": "("
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": ")"
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " "
+  },
+  "Minus": {
+    "unmodified": "[",
+    "withShift": "{"
+  },
+  "Equal": {
+    "unmodified": "]",
+    "withShift": "}"
+  },
+  "BracketLeft": {
+    "unmodified": "/",
+    "withShift": "?"
+  },
+  "BracketRight": {
+    "unmodified": "=",
+    "withShift": "+"
+  },
+  "Backslash": {
+    "unmodified": "\\",
+    "withShift": "|"
+  },
+  "Semicolon": {
+    "unmodified": "s",
+    "withShift": "S"
+  },
+  "Quote": {
+    "unmodified": "-",
+    "withShift": "_"
+  },
+  "Backquote": {
+    "unmodified": "`",
+    "withShift": "~"
+  },
+  "Comma": {
+    "unmodified": "w",
+    "withShift": "W"
+  },
+  "Period": {
+    "unmodified": "v",
+    "withShift": "V"
+  },
+  "Slash": {
+    "unmodified": "z",
+    "withShift": "Z"
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": null,
+    "withShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": null,
+    "withShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": null,
+    "withShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": null,
+    "withShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": null,
+    "withShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": null,
+    "withShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": null,
+    "withShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": null,
+    "withShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": null,
+    "withShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": null,
+    "withShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": null,
+    "withShift": "."
+  },
+  "IntlBackslash": {
+    "unmodified": "<",
+    "withShift": ">"
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "="
+  },
+  "NumpadComma": {
+    "unmodified": ".",
+    "withShift": "."
+  },
+  "NumpadParenLeft": {
+    "unmodified": "(",
+    "withShift": "("
+  },
+  "NumpadParenRight": {
+    "unmodified": ")",
+    "withShift": ")"
+  }
+}

--- a/spec/helpers/keymaps/linux-swiss-german.json
+++ b/spec/helpers/keymaps/linux-swiss-german.json
@@ -1,0 +1,274 @@
+{
+  "KeyA": {
+    "unmodified": "a",
+    "withShift": "A"
+  },
+  "KeyB": {
+    "unmodified": "b",
+    "withShift": "B"
+  },
+  "KeyC": {
+    "unmodified": "c",
+    "withShift": "C"
+  },
+  "KeyD": {
+    "unmodified": "d",
+    "withShift": "D"
+  },
+  "KeyE": {
+    "unmodified": "e",
+    "withShift": "E"
+  },
+  "KeyF": {
+    "unmodified": "f",
+    "withShift": "F"
+  },
+  "KeyG": {
+    "unmodified": "g",
+    "withShift": "G"
+  },
+  "KeyH": {
+    "unmodified": "h",
+    "withShift": "H"
+  },
+  "KeyI": {
+    "unmodified": "i",
+    "withShift": "I"
+  },
+  "KeyJ": {
+    "unmodified": "j",
+    "withShift": "J"
+  },
+  "KeyK": {
+    "unmodified": "k",
+    "withShift": "K"
+  },
+  "KeyL": {
+    "unmodified": "l",
+    "withShift": "L"
+  },
+  "KeyM": {
+    "unmodified": "m",
+    "withShift": "M"
+  },
+  "KeyN": {
+    "unmodified": "n",
+    "withShift": "N"
+  },
+  "KeyO": {
+    "unmodified": "o",
+    "withShift": "O"
+  },
+  "KeyP": {
+    "unmodified": "p",
+    "withShift": "P"
+  },
+  "KeyQ": {
+    "unmodified": "q",
+    "withShift": "Q"
+  },
+  "KeyR": {
+    "unmodified": "r",
+    "withShift": "R"
+  },
+  "KeyS": {
+    "unmodified": "s",
+    "withShift": "S"
+  },
+  "KeyT": {
+    "unmodified": "t",
+    "withShift": "T"
+  },
+  "KeyU": {
+    "unmodified": "u",
+    "withShift": "U"
+  },
+  "KeyV": {
+    "unmodified": "v",
+    "withShift": "V"
+  },
+  "KeyW": {
+    "unmodified": "w",
+    "withShift": "W"
+  },
+  "KeyX": {
+    "unmodified": "x",
+    "withShift": "X"
+  },
+  "KeyY": {
+    "unmodified": "z",
+    "withShift": "Z"
+  },
+  "KeyZ": {
+    "unmodified": "y",
+    "withShift": "Y"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "+"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "\""
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "*"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "�"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "&"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "/"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "("
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": ")"
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": "="
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": "�"
+  },
+  "Minus": {
+    "unmodified": "'",
+    "withShift": "?"
+  },
+  "Equal": {
+    "unmodified": "^",
+    "withShift": "`"
+  },
+  "BracketLeft": {
+    "unmodified": "�",
+    "withShift": "�"
+  },
+  "BracketRight": {
+    "unmodified": "�",
+    "withShift": "!"
+  },
+  "Backslash": {
+    "unmodified": "$",
+    "withShift": "�"
+  },
+  "Semicolon": {
+    "unmodified": "�",
+    "withShift": "�"
+  },
+  "Quote": {
+    "unmodified": "�",
+    "withShift": "�"
+  },
+  "Backquote": {
+    "unmodified": "�",
+    "withShift": "�"
+  },
+  "Comma": {
+    "unmodified": ",",
+    "withShift": ";"
+  },
+  "Period": {
+    "unmodified": ".",
+    "withShift": ":"
+  },
+  "Slash": {
+    "unmodified": "-",
+    "withShift": "_"
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": null,
+    "withShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": null,
+    "withShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": null,
+    "withShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": null,
+    "withShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": null,
+    "withShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": null,
+    "withShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": null,
+    "withShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": null,
+    "withShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": null,
+    "withShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": null,
+    "withShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": null,
+    "withShift": ","
+  },
+  "IntlBackslash": {
+    "unmodified": "<",
+    "withShift": ">"
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "="
+  },
+  "NumpadComma": {
+    "unmodified": ".",
+    "withShift": "."
+  },
+  "NumpadParenLeft": {
+    "unmodified": "(",
+    "withShift": "("
+  },
+  "NumpadParenRight": {
+    "unmodified": ")",
+    "withShift": ")"
+  }
+}

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -684,6 +684,13 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'e', altKey: true, altGraphKey: false})), 'alt-e')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'E', altKey: true, shiftKey: true, altGraphKey: false})), 'alt-shift-E')
 
+      it "falls back to the non-alt key if other modifiers are combined with ALtGraph on Linux", ->
+        mockProcessPlatform('linux')
+        currentKeymap = require('./helpers/keymaps/linux-swiss-german')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altGraphKey: true, ctrlKey: true})), 'ctrl-alt-g')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altGraphKey: true, metaKey: true})), 'alt-cmd-g')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altGraphKey: true, altKey: true})), 'alt-g')
+
       it "uses the keymap to fix incorrect KeyboardEvent.key values when ctrlKey is true", ->
         mockProcessPlatform('linux')
         currentKeymap = require('./helpers/keymaps/linux-dvorak')

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -702,9 +702,9 @@ describe "KeymapManager", ->
       it "falls back to the non-alt key if other modifiers are combined with ALtGraph on Linux", ->
         mockProcessPlatform('linux')
         currentKeymap = require('./helpers/keymaps/linux-swiss-german')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altGraphKey: true, ctrlKey: true})), 'ctrl-alt-g')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altGraphKey: true, metaKey: true})), 'alt-cmd-g')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altGraphKey: true, altKey: true})), 'alt-g')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', ctrlKey: true, modifierState: {AltGraph: true}})), 'ctrl-alt-g')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', metaKey: true, modifierState: {AltGraph: true}})), 'alt-cmd-g')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altKey: true, modifierState: {AltGraph: true}})), 'alt-g')
 
       it "uses the keymap to fix incorrect KeyboardEvent.key values when ctrlKey is true", ->
         mockProcessPlatform('linux')

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -684,6 +684,13 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'e', altKey: true, altGraphKey: false})), 'alt-e')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'E', altKey: true, shiftKey: true, altGraphKey: false})), 'alt-shift-E')
 
+      it "uses the keymap to fix incorrect KeyboardEvent.key values when ctrlKey is true", ->
+        mockProcessPlatform('linux')
+        currentKeymap = require('./helpers/keymaps/linux-dvorak')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'f', code: 'KeyF', ctrlKey: true})), 'ctrl-u')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'F', code: 'KeyF', ctrlKey: true, shiftKey: true})), 'ctrl-shift-U')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'F', code: 'KeyF', ctrlKey: true, altKey: true, shiftKey: true})), 'ctrl-alt-shift-U')
+
       it "converts non-latin keycaps to their U.S. counterpart for purposes of binding", ->
         mockProcessPlatform('darwin')
         currentKeymap = require('./helpers/keymaps/mac-greek')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -157,11 +157,14 @@ exports.keystrokeForKeyboardEvent = (event) ->
           ctrlKey = false
           altKey = false
       # Linux has a dedicated `AltGraph` key that is distinct from all other
-      # modifiers, so there is no potential ambiguity and we always honor
-      # AltGraph.
+      # modifiers, including LeftAlt. However, if AltGraph is used in
+      # combination with other modifiers, we want to treat it as a modifier and
+      # fall back to the non-alt-modified character.
       else if process.platform is 'linux'
-        if event.getModifierState('AltGraph')
-          altKey = false
+        nonAltModifiedKey = nonAltModifiedKeyForKeyboardEvent(event)
+        if (ctrlKey or altKey or metaKey) and nonAltModifiedKey
+          key = nonAltModifiedKey
+          altKey = event.getModifierState('AltGraph')
 
   # Use US equivalent character for non-latin characters in keystrokes with modifiers
   # or when using the dvorak-qwertycmd layout and holding down the command key.

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -120,6 +120,16 @@ exports.keystrokeForKeyboardEvent = (event) ->
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[key] ? key.toLowerCase()
   else
+    # Chrome has a bug on Linux: It always reports the U.S. layout value for
+    # KeyboardEvent.key when ctrlKey is true. We work around it by consulting
+    # the current keymap.
+    if process.platform is 'linux' and ctrlKey
+      if event.code and (characters = KeyboardLayout.getCurrentKeymap()?[event.code])
+        if event.shiftKey and characters.withShift?
+          key = characters.withShift
+        else if characters.unmodified?
+          key = characters.unmodified
+
     if event.getModifierState('AltGraph')
       # All macOS layouts have an alt-modified character variant for every
       # single key. Therefore, if we always favored the alt variant, it would

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -120,7 +120,7 @@ exports.keystrokeForKeyboardEvent = (event) ->
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[key] ? key.toLowerCase()
   else
-    if altKey
+    if event.getModifierState('AltGraph')
       # All macOS layouts have an alt-modified character variant for every
       # single key. Therefore, if we always favored the alt variant, it would
       # become impossible to bind `alt-*` to anything. Since `alt-*` bindings
@@ -139,7 +139,7 @@ exports.keystrokeForKeyboardEvent = (event) ->
       # keystroke, it likely to be the intended character, and we always
       # interpret it as such rather than favoring a `ctrl-alt-*` binding
       # intepretation.
-      else if process.platform is 'win32' and ctrlKey and event.code
+      else if process.platform is 'win32' and event.code
         nonAltModifiedKey = nonAltModifiedKeyForKeyboardEvent(event)
         if metaKey
           key = nonAltModifiedKey


### PR DESCRIPTION
This PR works around an issue on Linux where incorrect `KeyboardEvent.key` values are reported when `ctrlKey` is `true` for the event. We build a custom keymap via the `keyboard-layout` library and use it to determine the `key` when `ctrlKey` is `true`.

Also, we always fall back to the non alt-graph character when any modifiers besides alt-graph are depressed during the keystroke.