### PR TITLE
Downcase alphabetic characters unless shiftKey is true

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -638,6 +638,11 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'A', ctrlKey: true, shiftKey: true})), 'ctrl-shift-A')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '{', shiftKey: true})), '{')
 
+    describe "when the KeyboardEvent.key is a capital letter due to caps lock, but shift is not pressed", ->
+      it.only "converts the letter to lower case", ->
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'A', shiftKey: false})), 'a')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'A', shiftKey: false, altKey: true})), 'alt-a')
+
     describe "when the Dvorak QWERTY-⌘ layout is in use on macOS", ->
       it "uses the US layout equivalent when the command key is held down", ->
         mockProcessPlatform('darwin')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -153,6 +153,10 @@ exports.keystrokeForKeyboardEvent = (event) ->
         if event.getModifierState('AltGraph')
           altKey = false
 
+    # Avoid caps-lock captilizing the key without shift being actually pressed
+    unless shiftKey
+      key = key.toLowerCase()
+
   # Use US equivalent character for non-latin characters in keystrokes with modifiers
   # or when using the dvorak-qwertycmd layout and holding down the command key.
   if (key.length is 1 and not isLatinCharacter(key)) or


### PR DESCRIPTION
This avoids caps-lock capitalizing characters without shift being pressed.

/cc @Ben3eeE 