### PR TITLE
Work around Linux bug where '/' is unidentified with ctrl held down on Brazillian keyboards

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -713,12 +713,16 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', metaKey: true, modifierState: {AltGraph: true}})), 'alt-cmd-g')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altKey: true, modifierState: {AltGraph: true}})), 'alt-g')
 
-      it "uses the keymap to fix incorrect KeyboardEvent.key values when ctrlKey is true", ->
+      it "uses the keymap to fix incorrect KeyboardEvent.key values when ctrlKey is true on Linux", ->
         mockProcessPlatform('linux')
         currentKeymap = require('./helpers/keymaps/linux-dvorak')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'f', code: 'KeyF', ctrlKey: true})), 'ctrl-u')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'F', code: 'KeyF', ctrlKey: true, shiftKey: true})), 'ctrl-shift-U')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'F', code: 'KeyF', ctrlKey: true, altKey: true, shiftKey: true})), 'ctrl-alt-shift-U')
+
+      it "resolves events with a key value of Unknown and a code of IntlRo to '/' (this occurs on a Brazillian Portuguese keyboard layout on Mint Linux)", ->
+        mockProcessPlatform('linux')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Unidentified', code: 'IntlRo', ctrlKey: true})), 'ctrl-/')
 
       it "converts non-latin keycaps to their U.S. counterpart for purposes of binding", ->
         mockProcessPlatform('darwin')
@@ -737,7 +741,7 @@ describe "KeymapManager", ->
         mockProcessPlatform('windows')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD'})), 'd')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', shiftKey: true})), 'shift-D')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD', ctrlKey: true})), 'ctrl-d')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ',  code: 'KeyD', ctrlKey: true})), 'ctrl-d')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', ctrlKey: true, shiftKey: true})), 'ctrl-shift-D')
         # Don't use U.S. counterpart for latin characters
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ö', code: 'KeyX', metaKey: true})), 'cmd-ö')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -117,10 +117,14 @@ exports.keystrokeForKeyboardEvent = (event) ->
   if KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]?
     key = KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]
 
-  # Work around Chrome bug on Linux where NumpadDecimal key value is '' with
-  # NumLock disabled.
-  if process.platform is 'linux' and code is 'NumpadDecimal' and not event.getModifierState('NumLock')
-    key = 'delete'
+  # Work around Chrome bugs on Linux
+  if process.platform is 'linux'
+    # Fix NumpadDecimal key value being '' with NumLock disabled.
+    if code is 'NumpadDecimal' and not event.getModifierState('NumLock')
+      key = 'delete'
+    # Fix 'Unidentified' key value for '/' key on Brazillian keyboards
+    if code is 'IntlRo' and key is 'Unidentified' and ctrlKey
+      key = '/'
 
   isNonCharacterKey = key.length > 1
   if isNonCharacterKey


### PR DESCRIPTION
I was unable to reproduce the problem on Ubuntu, so I just look for the combination of a `KeyboardEvent.key` value of `Unidentified` combined with a `KeyboardEvent.code` value of `IntlRo`.

Refs https://github.com/atom/atom/issues/13076