### PR TITLE
Add public custom keystroke resolver API

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -98,7 +98,7 @@ parseKeystroke = (keystroke) ->
   keys.push(keystroke.substring(keyStart)) if keyStart < keystroke.length
   keys
 
-exports.keystrokeForKeyboardEvent = (event) ->
+exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
   {key, code, ctrlKey, altKey, shiftKey, metaKey} = event
 
   if key is 'Dead'
@@ -211,6 +211,17 @@ exports.keystrokeForKeyboardEvent = (event) ->
     keystroke += key
 
   keystroke = normalizeKeystroke("^#{keystroke}") if event.type is 'keyup'
+
+  if customKeystrokeResolvers?
+    for resolver in customKeystrokeResolvers
+      customKeystroke = resolver({
+        keystroke, event,
+        layoutName: KeyboardLayout.getCurrentKeyboardLayout(),
+        keymap: KeyboardLayout.getCurrentKeymap()
+      })
+      if customKeystroke
+        keystroke = normalizeKeystroke(customKeystroke)
+
   keystroke
 
 nonAltModifiedKeyForKeyboardEvent = (event) ->

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -109,6 +109,7 @@ class KeymapManager
   constructor: (options={}) ->
     @[key] = value for key, value of options
     @watchSubscriptions = {}
+    @customKeystrokeResolvers = []
     @clear()
     @enableDvorakQwertyWorkaroundIfNeeded()
 
@@ -623,7 +624,13 @@ class KeymapManager
   #
   # Returns a {String} describing the keystroke.
   keystrokeForKeyboardEvent: (event) ->
-    keystrokeForKeyboardEvent(event, @dvorakQwertyWorkaroundEnabled)
+    keystrokeForKeyboardEvent(event, @customKeystrokeResolvers)
+
+  addKeystrokeResolver: (resolver) ->
+    @customKeystrokeResolvers.push(resolver)
+    new Disposable =>
+      index = @customKeystrokeResolvers.indexOf(resolver)
+      @customKeystrokeResolvers.splice(index, 1) if index >= 0
 
   # Public: Get the number of milliseconds allowed before pending states caused
   # by partial matches of multi-keystroke bindings are terminated.

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -626,6 +626,24 @@ class KeymapManager
   keystrokeForKeyboardEvent: (event) ->
     keystrokeForKeyboardEvent(event, @customKeystrokeResolvers)
 
+  # Public: Customize translation of raw keyboard events to keystroke strings.
+  # This API is useful for working around Chrome bugs or changing how Atom
+  # resolves certain key combinations. If multiple resolvers are installed,
+  # the most recently-added resolver returning a string for a given keystroke
+  # takes precedence.
+  #
+  # * `resolver` A {Function} that returns a keystroke {String} and is called
+  #    with an object containing the following keys:
+  #    * `keystroke` The currently resolved keystroke string. If your function
+  #      returns a falsy value, this is how Atom will resolve your keystroke.
+  #    * `event` The raw DOM 3 `KeyboardEvent` being resolved. See the DOM API
+  #      documentation for more details.
+  #    * `layoutName` The OS-specific name of the current keyboard layout.
+  #    * `keymap` An object mapping DOM 3 `KeyboardEvent.code` values to objects
+  #      with the typed character for that key in each modifier state, based on
+  #      the current operating system layout.
+  #
+  # Returns a {Disposable} that removes the added resolver.
   addKeystrokeResolver: (resolver) ->
     @customKeystrokeResolvers.push(resolver)
     new Disposable =>

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -1,7 +1,6 @@
 CSON = require 'season'
 fs = require 'fs-plus'
 {isSelectorValid} = require 'clear-cut'
-{observeCurrentKeyboardLayout} = require 'keyboard-layout'
 path = require 'path'
 {File} = require 'pathwatcher'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
@@ -93,7 +92,6 @@ class KeymapManager
   defaultTarget: null
   pendingPartialMatches: null
   pendingStateTimeoutHandle: null
-  dvorakQwertyWorkaroundEnabled: false
 
   ###
   Section: Construction and Destruction
@@ -111,7 +109,6 @@ class KeymapManager
     @watchSubscriptions = {}
     @customKeystrokeResolvers = []
     @clear()
-    @enableDvorakQwertyWorkaroundIfNeeded()
 
   # Public: Clear all registered key bindings and enqueued keystrokes. For use
   # in tests.
@@ -124,15 +121,10 @@ class KeymapManager
 
   # Public: Unwatch all watched paths.
   destroy: ->
-    @keyboardLayoutSubscription.dispose()
     for filePath, subscription of @watchSubscriptions
       subscription.dispose()
 
     return
-
-  enableDvorakQwertyWorkaroundIfNeeded: ->
-    @keyboardLayoutSubscription = observeCurrentKeyboardLayout (layoutId) =>
-      @dvorakQwertyWorkaroundEnabled = (layoutId?.indexOf('DVORAK-QWERTYCMD') > -1)
 
   ###
   Section: Event Subscription
@@ -662,7 +654,7 @@ class KeymapManager
   ###
 
   simulateTextInput: (keydownEvent) ->
-    if character = characterForKeyboardEvent(keydownEvent, @dvorakQwertyWorkaroundEnabled)
+    if character = characterForKeyboardEvent(keydownEvent)
       textInputEvent = document.createEvent("TextEvent")
       textInputEvent.initTextEvent("textInput", true, true, window, character)
       keydownEvent.path[0].dispatchEvent(textInputEvent)


### PR DESCRIPTION
@atom/maintainers I thought I'd make you aware of this API since it may be useful to suggest to users experiencing weird edge cases with keystroke resolution. I plan to hotfix it to `1.12-releases` to ensure there's a fallback strategy for any remaining keyboard layout issues we may have missed with the internationalization improvements.

### Rationale

There are quite a few Chrome bugs related to keyboard events on Linux. In addition, user expectations sometimes differ from our default behavior with respect to how we should interpret modifier keys on international keyboards. Finally, there are special modifier keys and crazy layouts on Linux that we don't have time to support right now.

### Keystroke resolvers

The solution to all these problems and more is to allow users or packages to insert custom logic for resolving certain keyboard events to keystroke strings. When this PR lands, you'll be able to do something like the following.

```js
atom.keymaps.addKeystrokeResolver(({event}) => {
  if (event.code === 'KeyG' && event.altKey && event.ctrlKey) {
    return 'ctrl-@'
  }
})
```
See the [API documentation](https://github.com/atom/atom-keymap/compare/ns-custom-keystroke-resolvers?expand=1#diff-e16fbac5ca7abe6ad321283af3e6fe28R621) for more details.
