### PR TITLE
Don’t handle keyboard events that are part of IME compositions

### DIFF
--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -488,6 +488,13 @@ class KeymapManager
     #
     # Godspeed.
 
+    # When a keyboard event is part of IME composition, the keyCode is always
+    # 229, which is the "composition key code". This API is deprecated, but this
+    # is the most simple and reliable way we found to ignore keystrokes that are
+    # part of IME compositions.
+    if event.keyCode is 229
+      return
+
     # keystroke is the atom keybind syntax, e.g. 'ctrl-a'
     keystroke = @keystrokeForKeyboardEvent(event)
 


### PR DESCRIPTION
We detect IME compositions via a quirk in Chrome’s legacy KeyboardEvent.keyCode property, which is always 229 when a composition is in progress.

Closes #172
Closes #177

@ungb there's really no good way to test this programmatically. We'll need to always be sure to test IME interactions when we upgrade Electron, but it does seem really unlikely that the Chrome team is going to mess with any of these code paths because this `keyCode` property is deprecated.