### PR TITLE
Allow ctrl-alt- bindings to shadow non-ASCII AltGraph chars on Windows

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -715,15 +715,15 @@ describe "KeymapManager", ->
         # Does not use alt variant character if ctrl modifier is used
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', ctrlKey: true, altKey: true})), 'ctrl-alt-g')
 
-      it "allows any AltGraph-modified character to be typed via the ctrl-alt- modifiers on Windows", ->
+      it "allows ASCII characters (<= 127) to be typed via the ctrl-alt- modifiers on Windows", ->
         mockProcessPlatform('win32')
 
         currentKeymap = require('./helpers/keymaps/windows-swiss-german')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'Digit2', ctrlKey: true, altKey: true})), '@')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '°', code: 'Digit4', ctrlKey: true, altKey: true})), '°')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '°', code: 'Digit4', ctrlKey: true, altKey: true})), 'ctrl-alt-4')
 
         currentKeymap = require('./helpers/keymaps/windows-us-international')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '¢', code: 'KeyC', ctrlKey: true, altKey: true, shiftKey: true})), '¢')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '¢', code: 'KeyC', ctrlKey: true, altKey: true, shiftKey: true})), 'ctrl-alt-shift-C')
 
       it "allows arbitrary characters to be typed via an altgraph modifier on Linux", ->
         mockProcessPlatform('linux')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -156,7 +156,7 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
       # intepretation.
       else if process.platform is 'win32' and event.code
         nonAltModifiedKey = nonAltModifiedKeyForKeyboardEvent(event)
-        if nonAltModifiedKey and metaKey
+        if nonAltModifiedKey and (metaKey or not isASCIICharacter(key))
           key = nonAltModifiedKey
         else if key isnt nonAltModifiedKey
           ctrlKey = false


### PR DESCRIPTION
Closes #175

This is hopefully the last change we change our minds on this behavior. After this PR, it will always be possible to shadow a non ASCII character accessed via `AltGraph` or `ctrl-alt-` with a binding. This will create situations in which users can't type certain characters due to shadowed bindings, but they can `unset!` unset those bindings to free up the desired key. In 1.13 we will remove most default bindings involving ctrl-alt- to reduce the chances of collisions in the stock configuration.