### PR TITLE
Correctly handle the shift key when caps lock is on

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -671,6 +671,12 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'A', shiftKey: false})), 'a')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'A', shiftKey: false, altKey: true})), 'alt-a')
 
+    describe "when the KeyboardEvent.key is a lower-case letter due to caps lock + shift", ->
+      it "converts the letter to upper case and honors the shift key", ->
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', shiftKey: true})), 'shift-A')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', shiftKey: true, altKey: true})), 'alt-shift-A')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', shiftKey: true, ctrlKey: true})), 'ctrl-shift-A')
+
     describe "when the KeyboardEvent.key is 'Delete' but KeyboardEvent.code is 'Backspace' due to pressing ctrl-delete with numlock enabled on Windows", ->
       it "translates as ctrl-backspace instead of ctrl-delete", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Delete', code: 'Backspace', ctrlKey: true})), 'ctrl-backspace')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -171,8 +171,12 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
           key = nonAltModifiedKey
           altKey = event.getModifierState('AltGraph')
 
-    # Avoid caps-lock captilizing the key without shift being actually pressed
-    unless shiftKey
+    # Deal with caps-lock issues. Key bindings should always adjust the
+    # capitalization of the key based on the shiftKey state and never the state
+    # of the caps-lock key
+    if shiftKey
+      key = key.toUpperCase()
+    else
       key = key.toLowerCase()
 
   # Use US equivalent character for non-latin characters in keystrokes with modifiers


### PR DESCRIPTION
On Windows, shift with caps-lock enabled causes the character to be lower case. This corrects for that. We never want the state of caps lock to change keystroke resolution.