### PR TITLE
Always use U.S. layout characters when modifiers are used on non-Latin keyboards

### DIFF
--- a/spec/helpers/keymaps/mac-hebrew.json
+++ b/spec/helpers/keymaps/mac-hebrew.json
@@ -1,0 +1,398 @@
+{
+  "KeyA": {
+    "unmodified": "ש",
+    "withShift": "שׁ",
+    "withAltGraph": "שׂ",
+    "withAltGraphShift": "שׂ"
+  },
+  "KeyB": {
+    "unmodified": "נ",
+    "withShift": null,
+    "withAltGraph": "‘",
+    "withAltGraphShift": "֜"
+  },
+  "KeyC": {
+    "unmodified": "ב",
+    "withShift": "לֹ",
+    "withAltGraph": "“",
+    "withAltGraphShift": "֞"
+  },
+  "KeyD": {
+    "unmodified": "ג",
+    "withShift": "„",
+    "withAltGraph": "‏",
+    "withAltGraphShift": null
+  },
+  "KeyE": {
+    "unmodified": "ק",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyF": {
+    "unmodified": "כ",
+    "withShift": null,
+    "withAltGraph": "€",
+    "withAltGraphShift": "€"
+  },
+  "KeyG": {
+    "unmodified": "ע",
+    "withShift": null,
+    "withAltGraph": "֞",
+    "withAltGraphShift": null
+  },
+  "KeyH": {
+    "unmodified": "י",
+    "withShift": null,
+    "withAltGraph": "ײַ",
+    "withAltGraphShift": "ײַ"
+  },
+  "KeyI": {
+    "unmodified": "ן",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyJ": {
+    "unmodified": "ח",
+    "withShift": null,
+    "withAltGraph": "”",
+    "withAltGraphShift": null
+  },
+  "KeyK": {
+    "unmodified": "ל",
+    "withShift": "לֹ",
+    "withAltGraph": "֜",
+    "withAltGraphShift": null
+  },
+  "KeyL": {
+    "unmodified": "ך",
+    "withShift": null,
+    "withAltGraph": "’",
+    "withAltGraphShift": null
+  },
+  "KeyM": {
+    "unmodified": "צ",
+    "withShift": null,
+    "withAltGraph": "שׁ",
+    "withAltGraphShift": "שׁ"
+  },
+  "KeyN": {
+    "unmodified": "מ",
+    "withShift": null,
+    "withAltGraph": "’",
+    "withAltGraphShift": "’"
+  },
+  "KeyO": {
+    "unmodified": "ם",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyP": {
+    "unmodified": "פ",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyQ": {
+    "unmodified": "/",
+    "withShift": null,
+    "withAltGraph": "…",
+    "withAltGraphShift": "…"
+  },
+  "KeyR": {
+    "unmodified": "ר",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyS": {
+    "unmodified": "ד",
+    "withShift": null,
+    "withAltGraph": "‎",
+    "withAltGraphShift": null
+  },
+  "KeyT": {
+    "unmodified": "א",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyU": {
+    "unmodified": "ו",
+    "withShift": "וֹ",
+    "withAltGraph": "וּ",
+    "withAltGraphShift": "וּ"
+  },
+  "KeyV": {
+    "unmodified": "ה",
+    "withShift": null,
+    "withAltGraph": "”",
+    "withAltGraphShift": "”"
+  },
+  "KeyW": {
+    "unmodified": "׳",
+    "withShift": null,
+    "withAltGraph": "ָ",
+    "withAltGraphShift": "ָ"
+  },
+  "KeyX": {
+    "unmodified": "ס",
+    "withShift": null,
+    "withAltGraph": "—",
+    "withAltGraphShift": "—"
+  },
+  "KeyY": {
+    "unmodified": "ט",
+    "withShift": null,
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "KeyZ": {
+    "unmodified": "ז",
+    "withShift": null,
+    "withAltGraph": "–",
+    "withAltGraphShift": "–"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!",
+    "withAltGraph": "ֲ",
+    "withAltGraphShift": "ֲ"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "@",
+    "withAltGraph": "ֳ",
+    "withAltGraphShift": "ֳ"
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "#",
+    "withAltGraph": "ֱ",
+    "withAltGraphShift": "ֱ"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "$",
+    "withAltGraph": "ִ",
+    "withAltGraphShift": "ִ"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%",
+    "withAltGraph": "ֵ",
+    "withAltGraphShift": "ֵ"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "^",
+    "withAltGraph": "ַ",
+    "withAltGraphShift": "ַ"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "₪",
+    "withAltGraph": "ָ",
+    "withAltGraphShift": "ָ"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "*",
+    "withAltGraph": "ֻ",
+    "withAltGraphShift": "ֻ"
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": ")",
+    "withAltGraph": "ֶ",
+    "withAltGraphShift": "ֶ"
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": "(",
+    "withAltGraph": "ְ",
+    "withAltGraphShift": "ְ"
+  },
+  "Escape": {
+    "unmodified": null,
+    "withShift": null,
+    "withAltGraph": "‏",
+    "withAltGraphShift": "‎"
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " ",
+    "withAltGraph": " ",
+    "withAltGraphShift": " "
+  },
+  "Minus": {
+    "unmodified": "-",
+    "withShift": "_",
+    "withAltGraph": "-",
+    "withAltGraphShift": "-"
+  },
+  "Equal": {
+    "unmodified": "=",
+    "withShift": "+",
+    "withAltGraph": "ֹ",
+    "withAltGraphShift": "ֹ"
+  },
+  "BracketLeft": {
+    "unmodified": "]",
+    "withShift": "}",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "BracketRight": {
+    "unmodified": "[",
+    "withShift": "{",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Backslash": {
+    "unmodified": "ֿ",
+    "withShift": "|",
+    "withAltGraph": "־",
+    "withAltGraphShift": "־"
+  },
+  "Semicolon": {
+    "unmodified": "ף",
+    "withShift": ":",
+    "withAltGraph": ";",
+    "withAltGraphShift": ";"
+  },
+  "Quote": {
+    "unmodified": ",",
+    "withShift": "״",
+    "withAltGraph": "ֲ",
+    "withAltGraphShift": "ֲ"
+  },
+  "Backquote": {
+    "unmodified": ";",
+    "withShift": "~",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Comma": {
+    "unmodified": "ת",
+    "withShift": ">",
+    "withAltGraph": "ּ",
+    "withAltGraphShift": "ּ"
+  },
+  "Period": {
+    "unmodified": "ץ",
+    "withShift": "<",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "Slash": {
+    "unmodified": ".",
+    "withShift": "?",
+    "withAltGraph": null,
+    "withAltGraphShift": null
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/",
+    "withAltGraph": "/",
+    "withAltGraphShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*",
+    "withAltGraph": "*",
+    "withAltGraphShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-",
+    "withAltGraph": "-",
+    "withAltGraphShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+",
+    "withAltGraph": "+",
+    "withAltGraphShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": "1",
+    "withShift": "1",
+    "withAltGraph": "1",
+    "withAltGraphShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": "2",
+    "withShift": "2",
+    "withAltGraph": "2",
+    "withAltGraphShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": "3",
+    "withShift": "3",
+    "withAltGraph": "3",
+    "withAltGraphShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": "4",
+    "withShift": "4",
+    "withAltGraph": "4",
+    "withAltGraphShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": "5",
+    "withShift": "5",
+    "withAltGraph": "5",
+    "withAltGraphShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": "6",
+    "withShift": "6",
+    "withAltGraph": "6",
+    "withAltGraphShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": "7",
+    "withShift": "7",
+    "withAltGraph": "7",
+    "withAltGraphShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": "8",
+    "withShift": "8",
+    "withAltGraph": "8",
+    "withAltGraphShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": "9",
+    "withShift": "9",
+    "withAltGraph": "9",
+    "withAltGraphShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": "0",
+    "withShift": "0",
+    "withAltGraph": "0",
+    "withAltGraphShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": ".",
+    "withShift": ".",
+    "withAltGraph": ".",
+    "withAltGraphShift": "."
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "=",
+    "withAltGraph": "=",
+    "withAltGraphShift": "="
+  },
+  "AudioVolumeUp": {
+    "unmodified": null,
+    "withShift": "=",
+    "withAltGraph": "=",
+    "withAltGraphShift": "="
+  }
+}

--- a/spec/helpers/keymaps/mac-russian-pc.json
+++ b/spec/helpers/keymaps/mac-russian-pc.json
@@ -1,0 +1,398 @@
+{
+  "KeyA": {
+    "unmodified": "ф",
+    "withShift": "Ф",
+    "withAltGraph": "d",
+    "withAltGraphShift": "d"
+  },
+  "KeyB": {
+    "unmodified": "и",
+    "withShift": "И",
+    "withAltGraph": "і",
+    "withAltGraphShift": "І"
+  },
+  "KeyC": {
+    "unmodified": "с",
+    "withShift": "С",
+    "withAltGraph": "c",
+    "withAltGraphShift": "C"
+  },
+  "KeyD": {
+    "unmodified": "в",
+    "withShift": "В",
+    "withAltGraph": "ћ",
+    "withAltGraphShift": "Ћ"
+  },
+  "KeyE": {
+    "unmodified": "у",
+    "withShift": "У",
+    "withAltGraph": "ў",
+    "withAltGraphShift": "Ў"
+  },
+  "KeyF": {
+    "unmodified": "а",
+    "withShift": "А",
+    "withAltGraph": "÷",
+    "withAltGraphShift": "±"
+  },
+  "KeyG": {
+    "unmodified": "п",
+    "withShift": "П",
+    "withAltGraph": "…",
+    "withAltGraphShift": "√"
+  },
+  "KeyH": {
+    "unmodified": "р",
+    "withShift": "Р",
+    "withAltGraph": "•",
+    "withAltGraphShift": "∞"
+  },
+  "KeyI": {
+    "unmodified": "ш",
+    "withShift": "Ш",
+    "withAltGraph": "ѕ",
+    "withAltGraphShift": "Ѕ"
+  },
+  "KeyJ": {
+    "unmodified": "о",
+    "withShift": "О",
+    "withAltGraph": "∆",
+    "withAltGraphShift": "µ"
+  },
+  "KeyK": {
+    "unmodified": "л",
+    "withShift": "Л",
+    "withAltGraph": "љ",
+    "withAltGraphShift": "Љ"
+  },
+  "KeyL": {
+    "unmodified": "д",
+    "withShift": "Д",
+    "withAltGraph": "l",
+    "withAltGraphShift": "L"
+  },
+  "KeyM": {
+    "unmodified": "ь",
+    "withShift": "Ь",
+    "withAltGraph": "m",
+    "withAltGraphShift": "M"
+  },
+  "KeyN": {
+    "unmodified": "т",
+    "withShift": "Т",
+    "withAltGraph": "ƒ",
+    "withAltGraphShift": "ƒ"
+  },
+  "KeyO": {
+    "unmodified": "щ",
+    "withShift": "Щ",
+    "withAltGraph": "'",
+    "withAltGraphShift": "„"
+  },
+  "KeyP": {
+    "unmodified": "з",
+    "withShift": "З",
+    "withAltGraph": "‘",
+    "withAltGraphShift": "’"
+  },
+  "KeyQ": {
+    "unmodified": "й",
+    "withShift": "Й",
+    "withAltGraph": "ј",
+    "withAltGraphShift": "Ј"
+  },
+  "KeyR": {
+    "unmodified": "к",
+    "withShift": "К",
+    "withAltGraph": "ќ",
+    "withAltGraphShift": "Ќ"
+  },
+  "KeyS": {
+    "unmodified": "ы",
+    "withShift": "Ы",
+    "withAltGraph": "z",
+    "withAltGraphShift": "Z"
+  },
+  "KeyT": {
+    "unmodified": "е",
+    "withShift": "Е",
+    "withAltGraph": "†",
+    "withAltGraphShift": "†"
+  },
+  "KeyU": {
+    "unmodified": "г",
+    "withShift": "Г",
+    "withAltGraph": "ѓ",
+    "withAltGraphShift": "Ѓ"
+  },
+  "KeyV": {
+    "unmodified": "м",
+    "withShift": "М",
+    "withAltGraph": "v",
+    "withAltGraphShift": "V"
+  },
+  "KeyW": {
+    "unmodified": "ц",
+    "withShift": "Ц",
+    "withAltGraph": "џ",
+    "withAltGraphShift": "Џ"
+  },
+  "KeyX": {
+    "unmodified": "ч",
+    "withShift": "Ч",
+    "withAltGraph": "x",
+    "withAltGraphShift": "X"
+  },
+  "KeyY": {
+    "unmodified": "н",
+    "withShift": "Н",
+    "withAltGraph": "њ",
+    "withAltGraphShift": "Њ"
+  },
+  "KeyZ": {
+    "unmodified": "я",
+    "withShift": "Я",
+    "withAltGraph": "ђ",
+    "withAltGraphShift": "Ђ"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!",
+    "withAltGraph": "!",
+    "withAltGraphShift": "™"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "\"",
+    "withAltGraph": "@",
+    "withAltGraphShift": "§"
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "№",
+    "withAltGraph": "#",
+    "withAltGraphShift": "£"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": ";",
+    "withAltGraph": "$",
+    "withAltGraphShift": "€"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%",
+    "withAltGraph": "©",
+    "withAltGraphShift": "®"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": ":",
+    "withAltGraph": "^",
+    "withAltGraphShift": "¬"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "?",
+    "withAltGraph": "&",
+    "withAltGraphShift": "¶"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "*",
+    "withAltGraph": "₽",
+    "withAltGraphShift": "°"
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": "(",
+    "withAltGraph": "(",
+    "withAltGraphShift": "{"
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": ")",
+    "withAltGraph": ")",
+    "withAltGraphShift": "}"
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " ",
+    "withAltGraph": " ",
+    "withAltGraphShift": " "
+  },
+  "Minus": {
+    "unmodified": "-",
+    "withShift": "_",
+    "withAltGraph": "–",
+    "withAltGraphShift": "—"
+  },
+  "Equal": {
+    "unmodified": "=",
+    "withShift": "+",
+    "withAltGraph": "≠",
+    "withAltGraphShift": "≈"
+  },
+  "BracketLeft": {
+    "unmodified": "х",
+    "withShift": "Х",
+    "withAltGraph": "“",
+    "withAltGraphShift": "”"
+  },
+  "BracketRight": {
+    "unmodified": "ъ",
+    "withShift": "Ъ",
+    "withAltGraph": "«",
+    "withAltGraphShift": "»"
+  },
+  "Backslash": {
+    "unmodified": "\\",
+    "withShift": "/",
+    "withAltGraph": "\\",
+    "withAltGraphShift": "|"
+  },
+  "Semicolon": {
+    "unmodified": "ж",
+    "withShift": "Ж",
+    "withAltGraph": "«",
+    "withAltGraphShift": "»"
+  },
+  "Quote": {
+    "unmodified": "э",
+    "withShift": "Э",
+    "withAltGraph": "є",
+    "withAltGraphShift": "Є"
+  },
+  "Backquote": {
+    "unmodified": "]",
+    "withShift": "[",
+    "withAltGraph": "`",
+    "withAltGraphShift": "~"
+  },
+  "Comma": {
+    "unmodified": "б",
+    "withShift": "Б",
+    "withAltGraph": "≤",
+    "withAltGraphShift": "<"
+  },
+  "Period": {
+    "unmodified": "ю",
+    "withShift": "Ю",
+    "withAltGraph": "≥",
+    "withAltGraphShift": ">"
+  },
+  "Slash": {
+    "unmodified": ".",
+    "withShift": ",",
+    "withAltGraph": "ї",
+    "withAltGraphShift": "Ї"
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/",
+    "withAltGraph": "/",
+    "withAltGraphShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*",
+    "withAltGraph": "*",
+    "withAltGraphShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-",
+    "withAltGraph": "-",
+    "withAltGraphShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+",
+    "withAltGraph": "+",
+    "withAltGraphShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": "1",
+    "withShift": "1",
+    "withAltGraph": "1",
+    "withAltGraphShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": "2",
+    "withShift": "2",
+    "withAltGraph": "2",
+    "withAltGraphShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": "3",
+    "withShift": "3",
+    "withAltGraph": "3",
+    "withAltGraphShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": "4",
+    "withShift": "4",
+    "withAltGraph": "4",
+    "withAltGraphShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": "5",
+    "withShift": "5",
+    "withAltGraph": "5",
+    "withAltGraphShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": "6",
+    "withShift": "6",
+    "withAltGraph": "6",
+    "withAltGraphShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": "7",
+    "withShift": "7",
+    "withAltGraph": "7",
+    "withAltGraphShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": "8",
+    "withShift": "8",
+    "withAltGraph": "8",
+    "withAltGraphShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": "9",
+    "withShift": "9",
+    "withAltGraph": "9",
+    "withAltGraphShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": "0",
+    "withShift": "0",
+    "withAltGraph": "0",
+    "withAltGraphShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": ",",
+    "withShift": ",",
+    "withAltGraph": ",",
+    "withAltGraphShift": ","
+  },
+  "IntlBackslash": {
+    "unmodified": "ё",
+    "withShift": "Ё",
+    "withAltGraph": "§",
+    "withAltGraphShift": "±"
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "=",
+    "withAltGraph": "=",
+    "withAltGraphShift": "="
+  },
+  "AudioVolumeUp": {
+    "unmodified": null,
+    "withShift": "=",
+    "withAltGraph": null,
+    "withAltGraphShift": "="
+  }
+}

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -724,8 +724,7 @@ describe "KeymapManager", ->
         mockProcessPlatform('linux')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Unidentified', code: 'IntlRo', ctrlKey: true})), 'ctrl-/')
 
-      it "converts non-latin keycaps to their U.S. counterpart for purposes of binding", ->
-        mockProcessPlatform('darwin')
+      it "on non-Latin keyboards, converts keystrokes with modifiers to U.S. layout equivalent characters", ->
         currentKeymap = require('./helpers/keymaps/mac-greek')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD'})), 'd')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', shiftKey: true})), 'shift-D')
@@ -733,25 +732,15 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD', metaKey: true})), 'cmd-d')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', metaKey: true, shiftKey: true})), 'shift-cmd-D')
 
-        # Don't use U.S. counterpart for latin characters
+        # If *any* key on the keyboard is non-Latin, even characters that *are* Latin remap to the U.S. equivalent character for the physical key
+        currentKeymap = require('./helpers/keymaps/mac-russian-pc')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '.', code: 'Slash', ctrlKey: true})), 'ctrl-/')
+        currentKeymap = require('./helpers/keymaps/mac-hebrew')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: ']', code: 'BracketLeft', ctrlKey: true})), 'ctrl-[')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '[', code: 'BracketRight', ctrlKey: true})), 'ctrl-]')
+
+        # Don't use U.S. counterpart for keyboards with all Latin characters
         currentKeymap = require('./helpers/keymaps/mac-turkish')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ö', code: 'KeyX', metaKey: true})), 'cmd-ö')
-
-        currentKeymap = null
-        mockProcessPlatform('windows')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD'})), 'd')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', shiftKey: true})), 'shift-D')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ',  code: 'KeyD', ctrlKey: true})), 'ctrl-d')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', ctrlKey: true, shiftKey: true})), 'ctrl-shift-D')
-        # Don't use U.S. counterpart for latin characters
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ö', code: 'KeyX', metaKey: true})), 'cmd-ö')
-
-        mockProcessPlatform('linux')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD'})), 'd')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', shiftKey: true})), 'shift-D')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'δ', code: 'KeyD', ctrlKey: true})), 'ctrl-d')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Δ', code: 'KeyD', ctrlKey: true, shiftKey: true})), 'ctrl-shift-D')
-        # Don't use U.S. counterpart for latin characters
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ö', code: 'KeyX', metaKey: true})), 'cmd-ö')
 
       it "translates dead keys to their printable equivalents", ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -17,6 +17,22 @@ NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY = {
   'ArrowRight': 'right'
 }
 
+LATIN_KEYMAP_CACHE = new WeakMap()
+isLatinKeymap = (keymap) ->
+  return true unless keymap?
+
+  isLatin = LATIN_KEYMAP_CACHE.get(keymap)
+  if isLatin?
+    isLatin
+  else
+    isLatin =
+      isLatinCharacter(keymap.KeyA.unmodified) and
+        isLatinCharacter(keymap.KeyS.unmodified) and
+          isLatinCharacter(keymap.KeyD.unmodified) and
+            isLatinCharacter(keymap.KeyF.unmodified)
+    LATIN_KEYMAP_CACHE.set(keymap, isLatin)
+    isLatin
+
 isASCIICharacter = (character) ->
   character? and character.length is 1 and character.charCodeAt(0) <= 127
 
@@ -181,7 +197,7 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
 
   # Use US equivalent character for non-latin characters in keystrokes with modifiers
   # or when using the dvorak-qwertycmd layout and holding down the command key.
-  if (key.length is 1 and not isLatinCharacter(key)) or
+  if (key.length is 1 and not isLatinKeymap(KeyboardLayout.getCurrentKeymap())) or
      (metaKey and KeyboardLayout.getCurrentKeyboardLayout() is 'com.apple.keylayout.DVORAK-QWERTYCMD')
     if characters = usCharactersForKeyCode(event.code)
       if event.shiftKey


### PR DESCRIPTION
Closes #179

Previously, we only translated non-Latin characters to their U.S. equivalent, but on some keyboards such as Russian and Hebrew, latin symbols are in different locations and users expect key bindings to use the U.S. location for these symbols.

This commit checks entire *layouts* for being non-Latin by looking for non-Latin characters in the first 4 keys of the home row rather than testing characters on an individual basis. If the keyboard 
layout is detected to be non-Latin, we fall back to the U.S. layout for bindings across the board.

cc @Ben3eeE 