### PR TITLE
Don’t resolve dead keys on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.0.4",
     "grim": "^1.2.1",
-    "keyboard-layout": "2.0.2",
+    "keyboard-layout": "2.0.5",
     "pathwatcher": "^6.2",
     "property-accessors": "^1",
     "season": "^5.4.1"

--- a/spec/helpers/keymaps/windows-swedish.json
+++ b/spec/helpers/keymaps/windows-swedish.json
@@ -227,26 +227,14 @@
     "withAltGraph": "\\",
     "withAltGraphShift": null
   },
-  "Equal": {
-    "unmodified": "´",
-    "withShift": "`",
-    "withAltGraph": null,
-    "withAltGraphShift": null
-  },
   "BracketLeft": {
     "unmodified": "å",
     "withShift": "Å",
     "withAltGraph": null,
     "withAltGraphShift": null
   },
-  "BracketRight": {
-    "unmodified": "¨",
-    "withShift": "^",
-    "withAltGraph": "~",
-    "withAltGraphShift": null
-  },
   "Backslash": {
-    "unmodified": "~'",
+    "unmodified": "'",
     "withShift": "*",
     "withAltGraph": null,
     "withAltGraphShift": null

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -743,18 +743,20 @@ describe "KeymapManager", ->
         currentKeymap = require('./helpers/keymaps/mac-turkish')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ö', code: 'KeyX', metaKey: true})), 'cmd-ö')
 
-      it "translates dead keys to their printable equivalents", ->
+      it "translates dead keys to their printable equivalents on macOS, but not Windows", ->
         mockProcessPlatform('darwin')
         currentKeymap = require('./helpers/keymaps/mac-swedish')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight'})), '¨')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight', shiftKey: true})), '^')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight', altKey: true})), '~')
 
+        # We can't determine the character for a dead key on Windows without breaking dead key handling
+        # in some cases because they have a terrible API, so we don't try.
         mockProcessPlatform('win32')
         currentKeymap = require('./helpers/keymaps/windows-swedish')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight'})), '¨')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight', shiftKey: true})), '^')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight', ctrlKey: true, altKey: true, shiftKey: true})), '~')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight'})), 'dead')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight', shiftKey: true})), 'shift-dead')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Dead', code: 'BracketRight', ctrlKey: true, altKey: true, shiftKey: true})), 'ctrl-alt-shift-dead')
 
     describe "when custom keystroke resolvers are installed", ->
       it "resolves to the keystroke string of the most recently-installed resolver returning a defined value", ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -113,12 +113,10 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
   {key, code, ctrlKey, altKey, shiftKey, metaKey} = event
 
   if key is 'Dead'
-    if process.platform isnt 'linux' and characters = KeyboardLayout.getCurrentKeymap()?[event.code]
-      if ctrlKey and altKey and shiftKey and characters.withAltGraphShift?
+    if process.platform is 'darwin' and characters = KeyboardLayout.getCurrentKeymap()?[event.code]
+      if altKey and shiftKey and characters.withAltGraphShift?
         key = characters.withAltGraphShift
-      else if process.platform is 'darwin' and altKey and characters.withAltGraph?
-        key = characters.withAltGraph
-      else if process.platform is 'win32' and ctrlKey and altKey and characters.withAltGraph?
+      else if altKey and characters.withAltGraph?
         key = characters.withAltGraph
       else if shiftKey and characters.withShift?
         key = characters.withShift


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/13263
Refs https://github.com/atom/keyboard-layout/pull/19

This avoids a bug in Windows where dead key state is blown away if we attempt to get the character corresponding to a dead key. We now skip dead keys in `getCurrentkeymap` on Windows to avoid this issue, making it impossible to resolve dead keys to actual characters for the purposes of key bindings.