### PR TITLE
Restore ability to bind dead keys such as alt-u on macOS

### DIFF
--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -492,7 +492,7 @@ class KeymapManager
     # 229, which is the "composition key code". This API is deprecated, but this
     # is the most simple and reliable way we found to ignore keystrokes that are
     # part of IME compositions.
-    if event.keyCode is 229
+    if event.keyCode is 229 and event.key isnt 'Dead'
       return
 
     # keystroke is the atom keybind syntax, e.g. 'ctrl-a'


### PR DESCRIPTION
In a previous fix for IME in #178, we bail out of keystroke handling if the legacy `keyCode` property is `229`. Unfortunately, this is also the value of `keyCode` for keystrokes like `alt-u`, which don’t pop up the IME menu. These keystrokes can and should be handled normally. It seems like the best way to distinguish these keys from the IME case is that their key value is ‘Dead’.