### PR TITLE
Remove workaround when pressing a key while holding Ctrl on Linux

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -713,13 +713,6 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', metaKey: true, modifierState: {AltGraph: true}})), 'alt-cmd-g')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altKey: true, modifierState: {AltGraph: true}})), 'alt-g')
 
-      it "uses the keymap to fix incorrect KeyboardEvent.key values when ctrlKey is true on Linux", ->
-        mockProcessPlatform('linux')
-        currentKeymap = require('./helpers/keymaps/linux-dvorak')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'f', code: 'KeyF', ctrlKey: true})), 'ctrl-u')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'F', code: 'KeyF', ctrlKey: true, shiftKey: true})), 'ctrl-shift-U')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'F', code: 'KeyF', ctrlKey: true, altKey: true, shiftKey: true})), 'ctrl-alt-shift-U')
-
       it "resolves events with a key value of Unknown and a code of IntlRo to '/' (this occurs on a Brazillian Portuguese keyboard layout on Mint Linux)", ->
         mockProcessPlatform('linux')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Unidentified', code: 'IntlRo', ctrlKey: true})), 'ctrl-/')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -139,16 +139,6 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[key] ? key.toLowerCase()
   else
-    # Chrome has a bug on Linux: It always reports the U.S. layout value for
-    # KeyboardEvent.key when ctrlKey is true. We work around it by consulting
-    # the current keymap.
-    if process.platform is 'linux' and ctrlKey
-      if event.code and (characters = KeyboardLayout.getCurrentKeymap()?[event.code])
-        if event.shiftKey and characters.withShift?
-          key = characters.withShift
-        else if characters.unmodified?
-          key = characters.unmodified
-
     if event.getModifierState('AltGraph') or (process.platform is 'darwin' and altKey)
       # All macOS layouts have an alt-modified character variant for every
       # single key. Therefore, if we always favored the alt variant, it would


### PR DESCRIPTION
After shipping https://github.com/electron/electron/pull/8147 and https://github.com/atom/atom/pull/13353, Chrome should now report the correct `key` when holding down <kbd>Ctrl</kbd> and typing a character on Linux.

There might still be issues when holding <kbd>AltGr</kbd> and other modifier keys at the same time, as in that case we [retrieve information from X11](https://github.com/atom/atom-keymap/blob/e7d35a17c82081d178cc88e094d2daf1f7ba1735/src/helpers.coffee#L182-L186) to fall back to the non-alt-modified character, and that can cause issues on [some GNOME-based operating systems](https://github.com/atom/atom/issues/13170).

@Ben3eeE: it would be great if you can test this out so that we can merge this later today and put it in the hotfix if everything works as expected. ❤️ 