### PR TITLE
Resolve numpad differently to avoid conflict with Windows unicode entry

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -655,29 +655,29 @@ describe "KeymapManager", ->
 
     describe "when numlock is on", ->
       it "translates numpad digits using KeyboardEvent.code", ->
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '1', code: 'Numpad0', modifierState: {NumLock: true}})), 'numpad0')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '2', code: 'Numpad1', modifierState: {NumLock: true}})), 'numpad1')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '3', code: 'Numpad2', modifierState: {NumLock: true}})), 'numpad2')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '4', code: 'Numpad3', modifierState: {NumLock: true}})), 'numpad3')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '5', code: 'Numpad4', modifierState: {NumLock: true}})), 'numpad4')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad5', modifierState: {NumLock: true}})), 'numpad5')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '0', code: 'Numpad0', modifierState: {NumLock: true}})), 'numpad0')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '1', code: 'Numpad1', modifierState: {NumLock: true}})), 'numpad1')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '2', code: 'Numpad2', modifierState: {NumLock: true}})), 'numpad2')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '3', code: 'Numpad3', modifierState: {NumLock: true}})), 'numpad3')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '4', code: 'Numpad4', modifierState: {NumLock: true}})), 'numpad4')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '5', code: 'Numpad5', modifierState: {NumLock: true}})), 'numpad5')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad6', modifierState: {NumLock: true}})), 'numpad6')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '7', code: 'Numpad7', modifierState: {NumLock: true}})), 'numpad7')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '8', code: 'Numpad8', modifierState: {NumLock: true}})), 'numpad8')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '9', code: 'Numpad9', modifierState: {NumLock: true}})), 'numpad9')
 
     describe "when numlock is off", ->
-      it "doesn't translate numpad digits", ->
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '1', code: 'Numpad0', modifierState: {NumLock: false}})), 'insert')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '2', code: 'Numpad1', modifierState: {NumLock: false}})), 'end')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '3', code: 'Numpad2', modifierState: {NumLock: false}})), 'down')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '4', code: 'Numpad3', modifierState: {NumLock: false}})), 'pagedown')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '5', code: 'Numpad4', modifierState: {NumLock: false}})), 'left')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad5', modifierState: {NumLock: false}})), 'clear')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad6', modifierState: {NumLock: false}})), 'right')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '7', code: 'Numpad7', modifierState: {NumLock: false}})), 'home')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '8', code: 'Numpad8', modifierState: {NumLock: false}})), 'up')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '9', code: 'Numpad9', modifierState: {NumLock: false}})), 'pageup')
+      it "doesn't translate numpad digits using KeyboardEvent.code", ->
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Insert', code: 'Numpad0', modifierState: {NumLock: false}})), 'insert')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'End', code: 'Numpad1', modifierState: {NumLock: false}})), 'end')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ArrowDown', code: 'Numpad2', modifierState: {NumLock: false}})), 'down')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'PageDown', code: 'Numpad3', modifierState: {NumLock: false}})), 'pagedown')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ArrowLeft', code: 'Numpad4', modifierState: {NumLock: false}})), 'left')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Clear', code: 'Numpad5', modifierState: {NumLock: false}})), 'clear')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ArrowRight', code: 'Numpad6', modifierState: {NumLock: false}})), 'right')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Home', code: 'Numpad7', modifierState: {NumLock: false}})), 'home')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ArrowUp', code: 'Numpad8', modifierState: {NumLock: false}})), 'up')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'PageUp', code: 'Numpad9', modifierState: {NumLock: false}})), 'pageup')
 
     describe "when the Dvorak QWERTY-⌘ layout is in use on macOS", ->
       it "uses the US layout equivalent when the command key is held down", ->

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -653,6 +653,32 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '.', code: 'NumpadDecimal', modifierState: {NumLock: true}})), '.')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '', code: 'NumpadDecimal', modifierState: {NumLock: false}})), 'delete')
 
+    describe "when numlock is on", ->
+      it "translates numpad digits using KeyboardEvent.code", ->
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '1', code: 'Numpad0', modifierState: {NumLock: true}})), 'numpad0')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '2', code: 'Numpad1', modifierState: {NumLock: true}})), 'numpad1')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '3', code: 'Numpad2', modifierState: {NumLock: true}})), 'numpad2')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '4', code: 'Numpad3', modifierState: {NumLock: true}})), 'numpad3')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '5', code: 'Numpad4', modifierState: {NumLock: true}})), 'numpad4')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad5', modifierState: {NumLock: true}})), 'numpad5')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad6', modifierState: {NumLock: true}})), 'numpad6')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '7', code: 'Numpad7', modifierState: {NumLock: true}})), 'numpad7')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '8', code: 'Numpad8', modifierState: {NumLock: true}})), 'numpad8')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '9', code: 'Numpad9', modifierState: {NumLock: true}})), 'numpad9')
+
+    describe "when numlock is off", ->
+      it "doesn't translate numpad digits", ->
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '1', code: 'Numpad0', modifierState: {NumLock: false}})), 'insert')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '2', code: 'Numpad1', modifierState: {NumLock: false}})), 'end')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '3', code: 'Numpad2', modifierState: {NumLock: false}})), 'down')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '4', code: 'Numpad3', modifierState: {NumLock: false}})), 'pagedown')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '5', code: 'Numpad4', modifierState: {NumLock: false}})), 'left')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad5', modifierState: {NumLock: false}})), 'clear')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '6', code: 'Numpad6', modifierState: {NumLock: false}})), 'right')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '7', code: 'Numpad7', modifierState: {NumLock: false}})), 'home')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '8', code: 'Numpad8', modifierState: {NumLock: false}})), 'up')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '9', code: 'Numpad9', modifierState: {NumLock: false}})), 'pageup')
+
     describe "when the Dvorak QWERTY-⌘ layout is in use on macOS", ->
       it "uses the US layout equivalent when the command key is held down", ->
         mockProcessPlatform('darwin')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -16,7 +16,7 @@ NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY = {
   'ArrowLeft': 'left',
   'ArrowRight': 'right'
 }
-NUMPAD_KEYNAMES_BY_KEYBOARD_EVENT_CODE = {
+NUMPAD_KEY_NAMES_BY_KEYBOARD_EVENT_CODE = {
   'Numpad0': 'numpad0',
   'Numpad1': 'numpad1',
   'Numpad2': 'numpad2',
@@ -135,8 +135,8 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
       else if characters.unmodified?
         key = characters.unmodified
 
-  if NUMPAD_KEYNAMES_BY_KEYBOARD_EVENT_CODE[code]? and event.getModifierState('NumLock')
-    key = NUMPAD_KEYNAMES_BY_KEYBOARD_EVENT_CODE[code]
+  if NUMPAD_KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]? and event.getModifierState('NumLock')
+    key = NUMPAD_KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]
 
   if KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]?
     key = KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -16,6 +16,18 @@ NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY = {
   'ArrowLeft': 'left',
   'ArrowRight': 'right'
 }
+NUMPAD_KEYNAMES_BY_KEYBOARD_EVENT_CODE = {
+  'Numpad0': 'numpad0',
+  'Numpad1': 'numpad1',
+  'Numpad2': 'numpad2',
+  'Numpad3': 'numpad3',
+  'Numpad4': 'numpad4',
+  'Numpad5': 'numpad5',
+  'Numpad6': 'numpad6',
+  'Numpad7': 'numpad7',
+  'Numpad8': 'numpad8',
+  'Numpad9': 'numpad9'
+}
 
 LATIN_KEYMAP_CACHE = new WeakMap()
 isLatinKeymap = (keymap) ->
@@ -122,6 +134,9 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
         key = characters.withShift
       else if characters.unmodified?
         key = characters.unmodified
+
+  if NUMPAD_KEYNAMES_BY_KEYBOARD_EVENT_CODE[code]? and event.getModifierState('NumLock')
+    key = NUMPAD_KEYNAMES_BY_KEYBOARD_EVENT_CODE[code]
 
   if KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]?
     key = KEY_NAMES_BY_KEYBOARD_EVENT_CODE[code]


### PR DESCRIPTION
### Description of the Change

Windows uses <kbd>Alt-numpad</kbd> to insert unicode characters. `atom-keymap` currently resolves the numpad digits the same was as the numeric row which means that unicode entry will conflict with <kbd>Alt-number</kbd> bound keys. <kbd>Alt-number</kbd> is bound to `pane-show-item-[number]` which means you can't use <kbd>Alt-numpad</kbd> to enter unicode characters in Atom without changing pane items.

This changes the numpad digits to resolve to `numpad[number]` instead of just `[number]` by using `KeyboardEvent.code` when numlock is on to avoid conflict. Windows seems to still allow unicode entry when numlock is off which would conflict with keybindings but this seems to be the expected behavior on Windows after testing it in some common programs.

### Alternate Designs


### Benefits

Fixes https://github.com/atom/atom-keymap/issues/147 and allows us to enter unicode characters with the numpad on Windows without conflicting with Atoms default set of keybindings.

### Possible Drawbacks

* Someone relies on the current way we resolve keys
* This adds the change for all platforms. I don't know if this makes sense of Linux or mac. Linux seems to use a different method to insert unicode characters.

### Applicable Issues

Fixes https://github.com/atom/atom-keymap/issues/147