### PR TITLE
Always honor AltGraph on Linux

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -706,13 +706,6 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'e', altKey: true, altGraphKey: false})), 'alt-e')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'E', altKey: true, shiftKey: true, altGraphKey: false})), 'alt-shift-E')
 
-      it "falls back to the non-alt key if other modifiers are combined with ALtGraph on Linux", ->
-        mockProcessPlatform('linux')
-        currentKeymap = require('./helpers/keymaps/linux-swiss-german')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', ctrlKey: true, modifierState: {AltGraph: true}})), 'ctrl-alt-g')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', metaKey: true, modifierState: {AltGraph: true}})), 'alt-cmd-g')
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: '@', code: 'KeyG', altKey: true, modifierState: {AltGraph: true}})), 'alt-g')
-
       it "resolves events with a key value of Unknown and a code of IntlRo to '/' (this occurs on a Brazillian Portuguese keyboard layout on Mint Linux)", ->
         mockProcessPlatform('linux')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Unidentified', code: 'IntlRo', ctrlKey: true})), 'ctrl-/')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -165,15 +165,6 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
         else if key isnt nonAltModifiedKey
           ctrlKey = false
           altKey = false
-      # Linux has a dedicated `AltGraph` key that is distinct from all other
-      # modifiers, including LeftAlt. However, if AltGraph is used in
-      # combination with other modifiers, we want to treat it as a modifier and
-      # fall back to the non-alt-modified character.
-      else if process.platform is 'linux'
-        nonAltModifiedKey = nonAltModifiedKeyForKeyboardEvent(event)
-        if nonAltModifiedKey and (ctrlKey or altKey or metaKey)
-          key = nonAltModifiedKey
-          altKey = event.getModifierState('AltGraph')
 
     # Deal with caps-lock issues. Key bindings should always adjust the
     # capitalization of the key based on the shiftKey state and never the state


### PR DESCRIPTION
Previously, we were falling back to the non-modified character when AltGraph was combined with other modifiers. Since computing the native keymap is unreliable on Linux and the AltGraph key is distinct from Alt on that platform, this PR causes us to always honor the use of AltGraph in key biindngs.

see https://github.com/atom/atom/issues/13131#issuecomment-269111825 for additional context.

cc @Ben3eeE 