### PR TITLE
Don't replay events when all matches have only keyup suffixes

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -465,6 +465,22 @@ describe "KeymapManager", ->
         getFakeClock().tick(keymapManager.getPartialMatchTimeout())
         assert.deepEqual(events, ['abc-secret-code'])
 
+      it "does not replay any keystrokes due to the keyup suffix", ->
+        keymapManager.add "test",
+          "div.a":
+            "ctrl-y": "y-command-2"
+        elementA.addEventListener 'y-command-2', (e) -> events.push('y-keydown')
+
+        keymapManager.handleKeyboardEvent(buildKeydownEvent(key: 'y', ctrlKey: true, target: elementA))
+        getFakeClock().tick(keymapManager.getPartialMatchTimeout())
+        assert.deepEqual(events, ['y-keydown'])
+        keymapManager.handleKeyboardEvent(buildKeyupEvent(key: 'y', target: elementA))
+        getFakeClock().tick(keymapManager.getPartialMatchTimeout())
+        assert.deepEqual(events, ['y-keydown'])
+        keymapManager.handleKeyboardEvent(buildKeyupEvent(key: 'Control', target: elementA))
+        getFakeClock().tick(keymapManager.getPartialMatchTimeout())
+        assert.deepEqual(events, ['y-keydown', 'y-up-ctrl-keyup'])
+
     it "only counts entire keystrokes when checking for partial matches", ->
       element = $$ -> @div class: 'a'
       keymapManager.add 'test',

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -617,10 +617,10 @@ class KeymapManager
 
     @bindingsToDisable.push(dispatchedExactMatch) if dispatchedExactMatch
     if hasPartialMatches and shouldUsePartialMatches
-      enableTimeout = (
-        @pendingStateTimeoutHandle? or
-        dispatchedExactMatch? or
-        characterForKeyboardEvent(@queuedKeyboardEvents[0])?
+      enableTimeout = @pendingStateTimeoutHandle? or
+        not allPartialMatchesContainKeyupRemainder and (
+          dispatchedExactMatch? or
+          characterForKeyboardEvent(@queuedKeyboardEvents[0])?
       )
       enableTimeout = false if replay
       @enterPendingState(partialMatches, enableTimeout)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -530,7 +530,8 @@ class KeymapManager
     hasPartialMatches = partialMatches.length > 0
     shouldUsePartialMatches = hasPartialMatches
 
-    if isKeyup(keystroke)
+    eventIsKeyup = isKeyup(keystroke)
+    if eventIsKeyup
       exactMatchCandidates = exactMatchCandidates.concat(@pendingKeyupMatcher.getMatches(keystroke))
 
     # Determine if the current keystrokes match any bindings *exactly*. If we
@@ -620,7 +621,7 @@ class KeymapManager
       enableTimeout = @pendingStateTimeoutHandle? or
         not allPartialMatchesContainKeyupRemainder and (
           dispatchedExactMatch? or
-          characterForKeyboardEvent(@queuedKeyboardEvents[0])?
+          characterForKeyboardEvent(@queuedKeyboardEvents[0])? and not eventIsKeyup
       )
       enableTimeout = false if replay
       @enterPendingState(partialMatches, enableTimeout)


### PR DESCRIPTION
I believe this fixes #190, in which I found that binding a command to `alt-[` caused an errant "alt-character" to get inserted (MacOS + U.S keyboard layout) if alt is held down for a second.

The problem is that when `alt-[` is pressed, the timeout is triggered, with the `alt-[` left on the list of queued keys. When the timeout fires, the keys are replayed with the binding added to `@bindingsToDisable`, which is why the U+201C gets inserted. (Or if you have a 2nd command bound to `alt-[` it'll fire that instead). This problem is not specific to the `alt` key, but is most noticeable due to all the built-in Mac OS alt- key combos serving as shadowed bindings.

cc @iolsen

### Alternate Designs

I strove to keep this change as small as possible in the interest of fixing my immediate problem sooner.

However, I do find the complexity of the key handling algorithm uncomfortably complex, and I think it's largely due to the keyup semantics. I'm wondering: how would you feel about simplifying it so that instead of thinking of the keyup (`^foo`) as an event in the binding sequence, it's more like an annotation that just means "... and wait until foo is released." Which I'm hoping is sufficient for all real use cases.

More formally I'd propose:

 * keyups can only appear at the end of a binding (good: "alt-a ^alt", bad: "alt-a ^alt a")
 * keyups can only apply to modifier keys (bad: "alt-a ^alt-a")
 * there can only be one keyup (bad: "alt-shift-a ^alt ^shift") [alternatively we could just convert this to "alt-shift-a ^alt-shift"]
 * keyups can only specify the release of keys that were pressed earlier in the binding (bad: "alt-a ^ctrl")
 * such bindings will be queued for execution when the keydowns are performed when the keyup events occur

This would let us completely divorce the keyup handling from the keydown. i.e.:

```
on key down:

immediately fire the first exact match (with no keyups)
for each possible keyup suffix:
  Add the first such binding to a separate list of pendingKeyup bindings

on key up:

find bindings in pendingKeyup pending this key release and fire them.
(If there are multiple modifiers pending release, like `^alt-shift`, all need to be released.)
```

The last bullet above also removes some ugliness in the case where you want the keydown to give focus to another element until the keyup fires. I've run into this making the [tab-switcher](https://github.com/oggy/tab-switcher) plugin, where one often wants to override the built-in ctrl-tab keys, but the keydown gives focus to separate "tab list" element. To achieve the right result you need:

```
"atom-workspace":
  "ctrl-tab": "tab-switcher:next"
  "ctrl-tab ^ctrl": "unset!"

"ol.tab-switcher-tab-list":
  "^ctrl": "tab-switcher:select"
```

This is a little confusing & ugly -- more intuitive to me would be:

```
"atom-workspace":
  "ctrl-tab": "tab-switcher:next"
  "ctrl-tab ^ctrl": "tab-switcher:select"
```

Thoughts about this idea? Happy to have a go at implementing it, but wanted to get your feedback first.

### Benefits

Fixes #190.

### Possible Drawbacks

None.

### Applicable Issues

None.
