### PR TITLE
Avoid exceptions in isLatin if native keymap entries are undefined

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -736,6 +736,10 @@ describe "KeymapManager", ->
         currentKeymap = require('./helpers/keymaps/mac-turkish')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'ö', code: 'KeyX', metaKey: true})), 'cmd-ö')
 
+        # Don't blow up if A, S, D, or F don't have entries in the keymap
+        currentKeymap = {KeyA: null, KeyS: null, KeyD: null, KeyF: null}
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', code: 'KeyA', ctrlKey: true})), 'ctrl-a')
+
       it "translates dead keys to their printable equivalents on macOS, but not Windows", ->
         mockProcessPlatform('darwin')
         currentKeymap = require('./helpers/keymaps/mac-swedish')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -25,11 +25,13 @@ isLatinKeymap = (keymap) ->
   if isLatin?
     isLatin
   else
+    # To avoid exceptions, if the native keymap does not have entries for a key,
+    # assume that key is latin.
     isLatin =
-      isLatinCharacter(keymap.KeyA.unmodified) and
-        isLatinCharacter(keymap.KeyS.unmodified) and
-          isLatinCharacter(keymap.KeyD.unmodified) and
-            isLatinCharacter(keymap.KeyF.unmodified)
+      (not keymap.KeyA? or isLatinCharacter(keymap.KeyA.unmodified)) and
+      (not keymap.KeyS? or isLatinCharacter(keymap.KeyS.unmodified)) and
+      (not keymap.KeyD? or isLatinCharacter(keymap.KeyD.unmodified)) and
+      (not keymap.KeyF? or isLatinCharacter(keymap.KeyF.unmodified))
     LATIN_KEYMAP_CACHE.set(keymap, isLatin)
     isLatin
 


### PR DESCRIPTION
Fixes #206