### PR TITLE
Add an additional check for invalid keybindings before adding them

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -588,6 +588,15 @@ describe "KeymapManager", ->
       keymapManager.handleKeyboardEvent(event)
       assert(not event.defaultPrevented)
 
+    it "rejects bindings with a non object command", ->
+      stub(console, 'warn')
+      assert.equal(keymapManager.add('test', 'body': 'my-sweet-command:that-is-evil'), undefined)
+      assert.equal(console.warn.callCount, 1)
+
+      event = buildKeydownEvent(key: '0', target: document.body)
+      keymapManager.handleKeyboardEvent(event)
+      assert(not event.defaultPrevented)
+
     it "returns a disposable allowing the added bindings to be removed", ->
       disposable1 = keymapManager.add 'foo',
         '.a':

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -230,6 +230,10 @@ class KeymapManager
         console.warn("Encountered an invalid selector adding key bindings from '#{source}': '#{selector}'")
         return
 
+      unless typeof keyBindings is 'object'
+        console.warn("Encountered an invalid key binding when adding key bindings from '#{source}' '#{keyBinding}'")
+        return
+
       for keystrokes, command of keyBindings
         command = command?.toString?() ? ''
 

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -231,7 +231,7 @@ class KeymapManager
         return
 
       unless typeof keyBindings is 'object'
-        console.warn("Encountered an invalid key binding when adding key bindings from '#{source}' '#{keyBinding}'")
+        console.warn("Encountered an invalid key binding when adding key bindings from '#{source}' '#{keyBindings}'")
         return
 
       for keystrokes, command of keyBindings


### PR DESCRIPTION
### Description of the Change

When users add something like this to their `keymap.cson`:

```
'atom-text-editor':
  'my-evil-command:that-is-evil'
```

The command gets looped as a string in the [add function](https://github.com/atom/atom-keymap/blob/050e59ac5a09a2c7d5eedc600e7fe44eea5bbd2d/src/keymap-manager.coffee#L225). Causing 0 to become the keybinding for the first character in the command and 1 to be the keybinding for the second and so on. This makes it impossible to write numbers in the text editor.

This PR adds a check to ensure that the `keyBindings` is an Object before the loop to refuse adding these invalid keybindings.

### Alternate Designs

Other checks for same error. Happy to change this to an alternate design if someone has a better idea how to check for this,

### Benefits

* Fixes problems typing characters when the keymap contains invalid entries.

### Possible Drawbacks

* I never tested this in Atom because `atom-keymap` refused to link. So there might be some issues introduced by this that I didn't catch.

### Applicable Issues

https://github.com/atom/atom/issues/13497
https://github.com/atom/atom/issues/13872
https://github.com/atom/atom/issues/8769

