### PR TITLE
Ignore bindings with invalid selectors when throwOnInvalidSelector=false

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -570,6 +570,11 @@ describe "KeymapManager", ->
       keymapManager.handleKeyboardEvent(event)
       assert(not event.defaultPrevented)
 
+    it "ignores bindings with an invalid selector when throwOnInvalidSelector is false", ->
+      stub(console, 'warn')
+      assert.notEqual(keymapManager.add('test', {'<>': 'shift-a': 'a'}, 0, false), undefined)
+      assert.equal(console.warn.callCount, 0)
+
     it "rejects bindings with an empty command and logs a warning to the console", ->
       stub(console, 'warn')
       assert.equal(keymapManager.add('test', 'body': 'shift-a': ''), undefined)

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -222,11 +222,11 @@ class KeymapManager
   #   keystroke patterns to commands.
   # * `priority` A {Number} used to sort keybindings which have the same
   #   specificity. Defaults to `0`.
-  add: (source, keyBindingsBySelector, priority=0) ->
+  add: (source, keyBindingsBySelector, priority=0, throwOnInvalidSelector=true) ->
     addedKeyBindings = []
     for selector, keyBindings of keyBindingsBySelector
       # Verify selector is valid before registering any bindings
-      unless isSelectorValid(selector.replace(/!important/g, ''))
+      if throwOnInvalidSelector and not isSelectorValid(selector.replace(/!important/g, ''))
         console.warn("Encountered an invalid selector adding key bindings from '#{source}': '#{selector}'")
         return
 


### PR DESCRIPTION
This will prevent using `document.querySelector` to validate selectors when creating a snapshot, thus allowing us to load bundled keymaps as part of `script/build`.