### PR TITLE
Deal with caps lock issues on Windows

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -656,6 +656,8 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', shiftKey: true})), 'shift-A')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', shiftKey: true, altKey: true})), 'alt-shift-A')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'a', shiftKey: true, ctrlKey: true})), 'ctrl-shift-A')
+      it "doesn't drop the ctrl-alt modifiers when there is no AltGraph variant", ->
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'p', shiftKey: true, altKey: true, ctrlKey: true})), 'ctrl-alt-shift-P')
 
     describe "when the KeyboardEvent.key is 'Delete' but KeyboardEvent.code is 'Backspace' due to pressing ctrl-delete with numlock enabled on Windows", ->
       it "translates as ctrl-backspace instead of ctrl-delete", ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -152,18 +152,17 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
     if code is 'IntlRo' and key is 'Unidentified' and ctrlKey
       key = '/'
 
-  # Deal with caps-lock issues. Key bindings should always adjust the
-  # capitalization of the key based on the shiftKey state and never the state
-  # of the caps-lock key
-  if shiftKey
-    key = key.toUpperCase()
-  else
-    key = key.toLowerCase()
-
   isNonCharacterKey = key.length > 1
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[key] ? key.toLowerCase()
   else
+    # Deal with caps-lock issues. Key bindings should always adjust the
+    # capitalization of the key based on the shiftKey state and never the state
+    # of the caps-lock key
+    if shiftKey
+      key = key.toUpperCase()
+    else
+      key = key.toLowerCase()
     if event.getModifierState('AltGraph') or (process.platform is 'darwin' and altKey)
       # All macOS layouts have an alt-modified character variant for every
       # single key. Therefore, if we always favored the alt variant, it would

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -152,6 +152,14 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
     if code is 'IntlRo' and key is 'Unidentified' and ctrlKey
       key = '/'
 
+  # Deal with caps-lock issues. Key bindings should always adjust the
+  # capitalization of the key based on the shiftKey state and never the state
+  # of the caps-lock key
+  if shiftKey
+    key = key.toUpperCase()
+  else
+    key = key.toLowerCase()
+
   isNonCharacterKey = key.length > 1
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[key] ? key.toLowerCase()
@@ -191,14 +199,6 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
         if nonAltModifiedKey and (ctrlKey or altKey or metaKey)
           key = nonAltModifiedKey
           altKey = event.getModifierState('AltGraph')
-
-    # Deal with caps-lock issues. Key bindings should always adjust the
-    # capitalization of the key based on the shiftKey state and never the state
-    # of the caps-lock key
-    if shiftKey
-      key = key.toUpperCase()
-    else
-      key = key.toLowerCase()
 
   # Use US equivalent character for non-latin characters in keystrokes with modifiers
   # or when using the dvorak-qwertycmd layout and holding down the command key.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When dealing with caps lock issues we do it after dropping modifiers. This causes issues when `KeyboardEvent.key` is a lower-case letter because of caps lock and shift being depressed during the keystroke because `nonAltModifiedKeyForKeyboardEvent` returns the upper case letter. Since `P !== p` the modifiers are dropped.

This PR moves the caps lock issue dealing code up to before we drop modifiers to avoid this issue and adds a simple test for this behavior.

### Alternate Designs

Did not consider any alternate designs.

### Benefits

Fixes issues with caps lock and shift on Windows.

### Possible Drawbacks

I have not linked and tested this in Atom yet so there may be some other issues introduced by this.

### Applicable Issues

Fixes https://github.com/atom/atom-keymap/issues/216

/cc: @50Wliu