### PR TITLE
Don't touch `document` if `throwOnInvalidSelector` is false.

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -566,7 +566,7 @@ describe "KeymapManager", ->
 
     it "ignores bindings with an invalid selector when throwOnInvalidSelector is false", ->
       stub(console, 'warn')
-      assert.lengthOf(keymapManager.build('test', {'<>': 'shift-a': 'a'}, 0, false), 0)
+      assert.lengthOf(keymapManager.build('test', {'<>': 'shift-a': 'a'}, 0, false), 1)
       assert.equal(console.warn.callCount, 0)
 
     it "rejects bindings with an empty command and logs a warning to the console", ->

--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -226,9 +226,8 @@ class KeymapManager
     bindings = []
     for selector, keyBindings of keyBindingsBySelector
       # Verify selector is valid before registering any bindings
-      unless isSelectorValid(selector.replace(/!important/g, ''))
-        if throwOnInvalidSelector
-          console.warn("Encountered an invalid selector adding key bindings from '#{source}': '#{selector}'")
+      if throwOnInvalidSelector and not isSelectorValid(selector.replace(/!important/g, ''))
+        console.warn("Encountered an invalid selector adding key bindings from '#{source}': '#{selector}'")
         continue
 
       unless typeof keyBindings is 'object'


### PR DESCRIPTION
Fixes a snapshotting-related regression introduced in #218.