### PR TITLE
Fix issue matching a binding ending in a carat

### DIFF
--- a/spec/key-binding-spec.coffee
+++ b/spec/key-binding-spec.coffee
@@ -29,6 +29,9 @@ describe "KeyBinding", ->
       assert.equal(keyBindingArgHelper('a b c').matchesKeystrokes(['a', '^a', 'b', '^b']), 'partial')
       assert.equal(keyBindingArgHelper('a b c').matchesKeystrokes(['a', '^a', 'd', '^d']), false)
 
+    it "returns 'partial' correctly for bindings that end in ^", ->
+      assert.equal(keyBindingArgHelper('g a ^').matchesKeystrokes(['g', '^g', 'a', '^a']), 'partial')
+
     it "returns MATCH_TYPES.PENDING_KEYUP for bindings that match and contain a remainder of only keyup events", ->
       assert.equal(keyBindingArgHelper('a b ^b').matchesKeystrokes(['a', 'b']), MATCH_TYPES.PENDING_KEYUP)
 

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -77,7 +77,7 @@ class KeyBinding
             return false
 
       if isPartialMatch
-        bindingRemainderContainsOnlyKeyups = false unless bindingKeystroke.startsWith('^') and bindingKeystroke.length > 1
+        bindingRemainderContainsOnlyKeyups = false unless isKeyup(bindingKeystroke)
 
     # Bindings that match the beginning of the user's keystrokes are not a match.
     # e.g. This is not a match. It would have been a match on the previous keystroke:

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -77,7 +77,7 @@ class KeyBinding
             return false
 
       if isPartialMatch
-        bindingRemainderContainsOnlyKeyups = false unless bindingKeystroke.startsWith('^')
+        bindingRemainderContainsOnlyKeyups = false unless bindingKeystroke.startsWith('^') and bindingKeystroke.length > 1
 
     # Bindings that match the beginning of the user's keystrokes are not a match.
     # e.g. This is not a match. It would have been a match on the previous keystroke:


### PR DESCRIPTION
### Description of the Change

The check for bindingRemainderContainsOnlyKeyups was assuming no
bindings explicitly to '^' and only checking that the next keystroke
started with '^' rather than checking it was actually '^' followed by
another explicit keystroke.

This caused issues in certain cases when we had bindings to a sequence
such as `g ^`.

### Alternate Designs

Forcing everyone to bind explicitly to `shift-6` instead. This works but is less intuitive and less portable to different keyboard layouts.

### Benefits

Better support for keybindings for the carat keystroke (`^` ie: `shift-6` on a standard ANSI layout)

### Possible Drawbacks

Unknown.

### Applicable Issues

Bug found and discussed here: https://github.com/dvcrn/proton/issues/286