### PR TITLE
Add a workaround to resolve slovak correctly with the cmd key

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -66,7 +66,7 @@ usCharactersForKeyCode = (code) ->
 
 slovakCmdKeymap = null
 slovakCmdCharactersForKeyCode = (code) ->
-  slovakCmdKeymap ?= require('./slovak-cmd-keymap.coffee')
+  slovakCmdKeymap ?= require('./slovak-cmd-keymap')
   slovakCmdKeymap[code]
 
 exports.normalizeKeystrokes = (keystrokes) ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -73,7 +73,7 @@ slovakCmdCharactersForKeyCode = (code, layout) ->
   if layout is 'com.apple.keylayout.Slovak'
     slovakCmdKeymap[code]
   else
-    slovakCmdQwertyKeymap[code]
+    slovakQwertyCmdKeymap[code]
 
 exports.normalizeKeystrokes = (keystrokes) ->
   normalizedKeystrokes = []

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -64,6 +64,11 @@ usCharactersForKeyCode = (code) ->
   usKeymap ?= require('./us-keymap')
   usKeymap[code]
 
+slovakCmdKeymap = null
+slovakCmdCharactersForKeyCode = (code) ->
+  slovakCmdKeymap ?= require('./slovak-cmd-keymap.coffee')
+  slovakCmdKeymap[code]
+
 exports.normalizeKeystrokes = (keystrokes) ->
   normalizedKeystrokes = []
   for keystroke in keystrokes.split(WHITESPACE_REGEX)
@@ -163,6 +168,7 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
       key = key.toUpperCase()
     else
       key = key.toLowerCase()
+
     if event.getModifierState('AltGraph') or (process.platform is 'darwin' and altKey)
       # All macOS layouts have an alt-modified character variant for every
       # single key. Therefore, if we always favored the alt variant, it would
@@ -199,11 +205,23 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
           key = nonAltModifiedKey
           altKey = event.getModifierState('AltGraph')
 
+  # TODO: Remove the com.apple.keylayout.DVORAK-QWERTYCMD
+  # case when we are using an Electron version based on Chromium M62
+  # That issue was fixed in https://bugs.chromium.org/p/chromium/issues/detail?id=747358
   # Use US equivalent character for non-latin characters in keystrokes with modifiers
   # or when using the dvorak-qwertycmd layout and holding down the command key.
   if (key.length is 1 and not isLatinKeymap(KeyboardLayout.getCurrentKeymap())) or
      (metaKey and KeyboardLayout.getCurrentKeyboardLayout() is 'com.apple.keylayout.DVORAK-QWERTYCMD')
     if characters = usCharactersForKeyCode(event.code)
+      if event.shiftKey
+        key = characters.withShift
+      else
+        key = characters.unmodified
+
+  # Work around https://bugs.chromium.org/p/chromium/issues/detail?id=766800
+  # TODO: Remove this workaround when we are using an Electron version based on chrome M62
+  if metaKey and KeyboardLayout.getCurrentKeyboardLayout() is 'com.apple.keylayout.Slovak'
+    if characters = slovakCmdCharactersForKeyCode(event.code)
       if event.shiftKey
         key = characters.withShift
       else

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -228,7 +228,7 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
 
   # Work around https://bugs.chromium.org/p/chromium/issues/detail?id=766800
   # TODO: Remove this workaround when we are using an Electron version based on chrome M62
-  if metaKey and currentLayout is 'com.apple.keylayout.Slovak' or currentLayout is 'com.apple.keylaout.Slovak-QWERTY'
+  if metaKey and currentLayout is 'com.apple.keylayout.Slovak' or currentLayout is 'com.apple.keylayout.Slovak-QWERTY'
     if characters = slovakCmdCharactersForKeyCode(event.code, currentLayout)
       if event.shiftKey
         key = characters.withShift

--- a/src/slovak-cmd-keymap.coffee
+++ b/src/slovak-cmd-keymap.coffee
@@ -1,0 +1,266 @@
+module.exports = {
+  "KeyA": {
+    "unmodified": "a",
+    "withShift": "A"
+  },
+  "KeyB": {
+    "unmodified": "b",
+    "withShift": "B"
+  },
+  "KeyC": {
+    "unmodified": "c",
+    "withShift": "C"
+  },
+  "KeyD": {
+    "unmodified": "d",
+    "withShift": "D"
+  },
+  "KeyE": {
+    "unmodified": "e",
+    "withShift": "E"
+  },
+  "KeyF": {
+    "unmodified": "f",
+    "withShift": "F"
+  },
+  "KeyG": {
+    "unmodified": "g",
+    "withShift": "G"
+  },
+  "KeyH": {
+    "unmodified": "h",
+    "withShift": "H"
+  },
+  "KeyI": {
+    "unmodified": "i",
+    "withShift": "I"
+  },
+  "KeyJ": {
+    "unmodified": "j",
+    "withShift": "J"
+  },
+  "KeyK": {
+    "unmodified": "k",
+    "withShift": "K"
+  },
+  "KeyL": {
+    "unmodified": "l",
+    "withShift": "L"
+  },
+  "KeyM": {
+    "unmodified": "m",
+    "withShift": "M"
+  },
+  "KeyN": {
+    "unmodified": "n",
+    "withShift": "N"
+  },
+  "KeyO": {
+    "unmodified": "o",
+    "withShift": "O"
+  },
+  "KeyP": {
+    "unmodified": "p",
+    "withShift": "P"
+  },
+  "KeyQ": {
+    "unmodified": "q",
+    "withShift": "Q"
+  },
+  "KeyR": {
+    "unmodified": "r",
+    "withShift": "R"
+  },
+  "KeyS": {
+    "unmodified": "s",
+    "withShift": "S"
+  },
+  "KeyT": {
+    "unmodified": "t",
+    "withShift": "T"
+  },
+  "KeyU": {
+    "unmodified": "u",
+    "withShift": "U"
+  },
+  "KeyV": {
+    "unmodified": "v",
+    "withShift": "V"
+  },
+  "KeyW": {
+    "unmodified": "w",
+    "withShift": "W"
+  },
+  "KeyX": {
+    "unmodified": "x",
+    "withShift": "X"
+  },
+  "KeyY": {
+    "unmodified": "z",
+    "withShift": "Z"
+  },
+  "KeyZ": {
+    "unmodified": "y",
+    "withShift": "Y"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "@"
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "#"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "$"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "^"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "&"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "*"
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": "("
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": ")"
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " "
+  },
+  "Minus": {
+    "unmodified": "=",
+    "withShift": null # TODO: What is this?
+  },
+  "Equal": {
+    "unmodified": "/",
+    "withShift": null # TODO: What is this?
+  },
+  "BracketLeft": {
+    "unmodified": "[",
+    "withShift": "{"
+  },
+  "BracketRight": {
+    "unmodified": "]",
+    "withShift": "}"
+  },
+  "Backslash": {
+    "unmodified": "`",
+    "withShift": null # TODO: What is this?
+  },
+  "Semicolon": {
+    "unmodified": ";",
+    "withShift": ":"
+  },
+  "Quote": {
+    "unmodified": "'",
+    "withShift": "\""
+  },
+  "Backquote": {
+    "unmodified": "\\",
+    "withShift": null # TODO: What is this?
+  },
+  "Comma": {
+    "unmodified": ",",
+    "withShift": "<"
+  },
+  "Period": {
+    "unmodified": ".",
+    "withShift": ">"
+  },
+  "Slash": {
+    "unmodified": "-",
+    "withShift": null # TODO: What is this?
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": "1",
+    "withShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": "2",
+    "withShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": "3",
+    "withShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": "4",
+    "withShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": "5",
+    "withShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": "6",
+    "withShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": "7",
+    "withShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": "8",
+    "withShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": "9",
+    "withShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": "0",
+    "withShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": ".",
+    "withShift": "."
+  },
+  "IntlBackslash": {
+    "unmodified": "§",
+    "withShift": "±"
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "="
+  },
+  "AudioVolumeUp": {
+    "unmodified": null,
+    "withShift": "="
+  }
+}

--- a/src/slovak-qwerty-cmd-keymap.coffee
+++ b/src/slovak-qwerty-cmd-keymap.coffee
@@ -1,0 +1,266 @@
+module.exports = {
+  "KeyA": {
+    "unmodified": "a",
+    "withShift": "A"
+  },
+  "KeyB": {
+    "unmodified": "b",
+    "withShift": "B"
+  },
+  "KeyC": {
+    "unmodified": "c",
+    "withShift": "C"
+  },
+  "KeyD": {
+    "unmodified": "d",
+    "withShift": "D"
+  },
+  "KeyE": {
+    "unmodified": "e",
+    "withShift": "E"
+  },
+  "KeyF": {
+    "unmodified": "f",
+    "withShift": "F"
+  },
+  "KeyG": {
+    "unmodified": "g",
+    "withShift": "G"
+  },
+  "KeyH": {
+    "unmodified": "h",
+    "withShift": "H"
+  },
+  "KeyI": {
+    "unmodified": "i",
+    "withShift": "I"
+  },
+  "KeyJ": {
+    "unmodified": "j",
+    "withShift": "J"
+  },
+  "KeyK": {
+    "unmodified": "k",
+    "withShift": "K"
+  },
+  "KeyL": {
+    "unmodified": "l",
+    "withShift": "L"
+  },
+  "KeyM": {
+    "unmodified": "m",
+    "withShift": "M"
+  },
+  "KeyN": {
+    "unmodified": "n",
+    "withShift": "N"
+  },
+  "KeyO": {
+    "unmodified": "o",
+    "withShift": "O"
+  },
+  "KeyP": {
+    "unmodified": "p",
+    "withShift": "P"
+  },
+  "KeyQ": {
+    "unmodified": "q",
+    "withShift": "Q"
+  },
+  "KeyR": {
+    "unmodified": "r",
+    "withShift": "R"
+  },
+  "KeyS": {
+    "unmodified": "s",
+    "withShift": "S"
+  },
+  "KeyT": {
+    "unmodified": "t",
+    "withShift": "T"
+  },
+  "KeyU": {
+    "unmodified": "u",
+    "withShift": "U"
+  },
+  "KeyV": {
+    "unmodified": "v",
+    "withShift": "V"
+  },
+  "KeyW": {
+    "unmodified": "w",
+    "withShift": "W"
+  },
+  "KeyX": {
+    "unmodified": "x",
+    "withShift": "X"
+  },
+  "KeyY": {
+    "unmodified": "y",
+    "withShift": "Y"
+  },
+  "KeyZ": {
+    "unmodified": "z",
+    "withShift": "Z"
+  },
+  "Digit1": {
+    "unmodified": "1",
+    "withShift": "!"
+  },
+  "Digit2": {
+    "unmodified": "2",
+    "withShift": "@"
+  },
+  "Digit3": {
+    "unmodified": "3",
+    "withShift": "#"
+  },
+  "Digit4": {
+    "unmodified": "4",
+    "withShift": "$"
+  },
+  "Digit5": {
+    "unmodified": "5",
+    "withShift": "%"
+  },
+  "Digit6": {
+    "unmodified": "6",
+    "withShift": "^"
+  },
+  "Digit7": {
+    "unmodified": "7",
+    "withShift": "&"
+  },
+  "Digit8": {
+    "unmodified": "8",
+    "withShift": "*"
+  },
+  "Digit9": {
+    "unmodified": "9",
+    "withShift": "("
+  },
+  "Digit0": {
+    "unmodified": "0",
+    "withShift": ")"
+  },
+  "Space": {
+    "unmodified": " ",
+    "withShift": " "
+  },
+  "Minus": {
+    "unmodified": "=",
+    "withShift": null # TODO: What is this?
+  },
+  "Equal": {
+    "unmodified": "/",
+    "withShift": null # TODO: What is this?
+  },
+  "BracketLeft": {
+    "unmodified": "[",
+    "withShift": "{"
+  },
+  "BracketRight": {
+    "unmodified": "]",
+    "withShift": "}"
+  },
+  "Backslash": {
+    "unmodified": "`",
+    "withShift": null # TODO: What is this?
+  },
+  "Semicolon": {
+    "unmodified": ";",
+    "withShift": ":"
+  },
+  "Quote": {
+    "unmodified": "'",
+    "withShift": "\""
+  },
+  "Backquote": {
+    "unmodified": "\\",
+    "withShift": null # TODO: What is this?
+  },
+  "Comma": {
+    "unmodified": ",",
+    "withShift": "<"
+  },
+  "Period": {
+    "unmodified": ".",
+    "withShift": ">"
+  },
+  "Slash": {
+    "unmodified": "-",
+    "withShift": null # TODO: What is this?
+  },
+  "NumpadDivide": {
+    "unmodified": "/",
+    "withShift": "/"
+  },
+  "NumpadMultiply": {
+    "unmodified": "*",
+    "withShift": "*"
+  },
+  "NumpadSubtract": {
+    "unmodified": "-",
+    "withShift": "-"
+  },
+  "NumpadAdd": {
+    "unmodified": "+",
+    "withShift": "+"
+  },
+  "Numpad1": {
+    "unmodified": "1",
+    "withShift": "1"
+  },
+  "Numpad2": {
+    "unmodified": "2",
+    "withShift": "2"
+  },
+  "Numpad3": {
+    "unmodified": "3",
+    "withShift": "3"
+  },
+  "Numpad4": {
+    "unmodified": "4",
+    "withShift": "4"
+  },
+  "Numpad5": {
+    "unmodified": "5",
+    "withShift": "5"
+  },
+  "Numpad6": {
+    "unmodified": "6",
+    "withShift": "6"
+  },
+  "Numpad7": {
+    "unmodified": "7",
+    "withShift": "7"
+  },
+  "Numpad8": {
+    "unmodified": "8",
+    "withShift": "8"
+  },
+  "Numpad9": {
+    "unmodified": "9",
+    "withShift": "9"
+  },
+  "Numpad0": {
+    "unmodified": "0",
+    "withShift": "0"
+  },
+  "NumpadDecimal": {
+    "unmodified": ".",
+    "withShift": "."
+  },
+  "IntlBackslash": {
+    "unmodified": "§",
+    "withShift": "±"
+  },
+  "NumpadEqual": {
+    "unmodified": "=",
+    "withShift": "="
+  },
+  "AudioVolumeUp": {
+    "unmodified": null,
+    "withShift": "="
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/atom/atom-keymap/issues/223

Refs: https://bugs.chromium.org/p/chromium/issues/detail?id=7668003
Refs: https://bugs.chromium.org/p/chromium/issues/detail?id=747358

/cc: @rsese @ungb I have no idea if this works or not because I don't own a mac. I did not test this at all.