### PR TITLE
Support custom dvorak QWERTYCMD layouts

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -702,7 +702,7 @@ describe "KeymapManager", ->
       it "uses the US layout equivalent when the command key is held down", ->
         mockProcessPlatform('darwin')
         stub(KeyboardLayout, 'getCurrentKeymap', -> require('./helpers/keymaps/mac-dvorak-qwerty-cmd'))
-        stub(KeyboardLayout, 'getCurrentKeyboardLayout', -> 'DVORAK-QWERTYCMD')
+        stub(KeyboardLayout, 'getCurrentKeyboardLayout', -> 'org.unknown.keylayout.DVORAK-QWERTYCMD')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', altKey: true})), 'alt-l')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', ctrlKey: true, altKey: true})), 'ctrl-alt-l')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', metaKey: true})), 'cmd-p')

--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -698,6 +698,16 @@ describe "KeymapManager", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', metaKey: true})), 'cmd-p')
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'L', code: 'KeyP', metaKey: true, shiftKey: true})), 'shift-cmd-P')
 
+    describe "when a custom Dvorak QWERTY-⌘ layout is in use on macOS", ->
+      it "uses the US layout equivalent when the command key is held down", ->
+        mockProcessPlatform('darwin')
+        stub(KeyboardLayout, 'getCurrentKeymap', -> require('./helpers/keymaps/mac-dvorak-qwerty-cmd'))
+        stub(KeyboardLayout, 'getCurrentKeyboardLayout', -> 'DVORAK-QWERTYCMD')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', altKey: true})), 'alt-l')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', ctrlKey: true, altKey: true})), 'ctrl-alt-l')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'l', code: 'KeyP', metaKey: true})), 'cmd-p')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'L', code: 'KeyP', metaKey: true, shiftKey: true})), 'shift-cmd-P')
+
     describe "when the current system keymap cannot be obtained on macOS", ->
       it "does not throw exceptions and just takes the current key value", ->
         mockProcessPlatform('darwin')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -219,7 +219,7 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
   # Use US equivalent character for non-latin characters in keystrokes with modifiers
   # or when using the dvorak-qwertycmd layout and holding down the command key.
   if (key.length is 1 and not isLatinKeymap(KeyboardLayout.getCurrentKeymap())) or
-     (metaKey and currentLayout is 'com.apple.keylayout.DVORAK-QWERTYCMD')
+     (metaKey and currentLayout.indexOf('DVORAK-QWERTYCMD') > -1)
     if characters = usCharactersForKeyCode(event.code)
       if event.shiftKey
         key = characters.withShift


### PR DESCRIPTION
# 🚨 DO NOT MERGE WITHOUT TESTING 🚨 

Restores #90 
Fixes https://github.com/atom/atom-keymap/issues/225

When restoring this in https://github.com/atom/atom-keymap/commit/b823c1e5e3a809ab51479d75a7d97dbc1538b3a9 it seems that we did not consider the changes that were added in #90 to enable the workaround for custom DVORAK-QWERTYCMD layouts.

This PR aims to restore this behavior and adds a test so it doesn't regress in the future!

/cc: @ungb @rsese 