### PR TITLE
Add aborted bindings to the did-match-binding event

### DIFF
--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -144,6 +144,8 @@ class KeymapManager
   #     * `binding` {KeyBinding} that the keystrokes matched.
   #     * `keyboardEventTarget` DOM element that was the target of the most
   #        recent keyboard event.
+  #     * `abortedBindings` {KeyBinding} objects that were matched but the command aborted itself
+  #        prior to `binding` being executed.
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidMatchBinding: (callback) ->
@@ -547,6 +549,8 @@ class KeymapManager
     if isKeyup(keystroke)
       exactMatchCandidates = exactMatchCandidates.concat(@pendingKeyupMatcher.getMatches(keystroke))
 
+    abortedBindings = []
+
     # Determine if the current keystrokes match any bindings *exactly*. If we
     # do find an exact match, the next step depends on whether we have any
     # partial matches. If we have no partial matches, we dispatch the command
@@ -595,6 +599,9 @@ class KeymapManager
             for pendingKeyupMatch in pendingKeyupMatchCandidates
               @pendingKeyupMatcher.addPendingMatch(pendingKeyupMatch)
             break
+          else
+            abortedBindings.push(exactMatchCandidate)
+
         currentTarget = currentTarget.parentElement
 
     # Emit events. These are done on their own for clarity.
@@ -604,7 +611,8 @@ class KeymapManager
         keystrokes,
         eventType: event.type,
         binding: dispatchedExactMatch,
-        keyboardEventTarget: target
+        keyboardEventTarget: target,
+        abortedBindings
       }
     else if hasPartialMatches and shouldUsePartialMatches
       event.preventDefault()


### PR DESCRIPTION
### Description of the Change

Why keybindings act the way that they do is sometimes a mystery to Atom users. One of the ways that isn't surfaced well is when one keybinding is aborted and another is executed in its place. This change adds a list of aborted bindings to the `onDidMatchBinding` event so they can be surfaced in the [keybinding-resolver package](https://github.com/atom/keybinding-resolver).

### Alternate Designs

None considered.

### Benefits

People will be able to debug their keybindings better.

### Possible Drawbacks

The difference between the `abort!` command name and the `e.abortKeyBinding` function is also not well understood. This change may confuse some Atom users by making that difference more visible.

### Applicable Issues

N/A