### PR TITLE
Don't resolve backspace using KeyboardEvent.code

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -652,10 +652,6 @@ describe "KeymapManager", ->
       it "doesn't drop the ctrl-alt modifiers when there is no AltGraph variant", ->
         assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'p', shiftKey: true, altKey: true, ctrlKey: true})), 'ctrl-alt-shift-P')
 
-    describe "when the KeyboardEvent.key is 'Delete' but KeyboardEvent.code is 'Backspace' due to pressing ctrl-delete with numlock enabled on Windows", ->
-      it "translates as ctrl-backspace instead of ctrl-delete", ->
-        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'Delete', code: 'Backspace', ctrlKey: true})), 'ctrl-backspace')
-
     describe "when the KeyboardEvent.key is '' but the KeyboardEvent.code is 'NumpadDecimal' and getModifierState('NumLock') returns false", ->
       it "translates as delete to work around a Chrome bug on Linux", ->
         mockProcessPlatform('linux')

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -6,7 +6,6 @@ ENDS_IN_MODIFIER_REGEX = /(ctrl|alt|shift|cmd)$/
 WHITESPACE_REGEX = /\s+/
 KEY_NAMES_BY_KEYBOARD_EVENT_CODE = {
   'Space': 'space',
-  'Backspace': 'backspace'
 }
 NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY = {
   'Control': 'ctrl',


### PR DESCRIPTION
### Description of the Change

When international keyboard support shipped there was bug in Chrome where ctrl-backspace sometimes resolved to ctrl-delete on Windows when Num Lock was on. This bug has been fixed in Electron 1.6 so the workaround is no longer needed.

### Alternate Designs

N/A

### Benefits

Better keystroke resolution on across all platforms

### Possible Drawbacks

This code is required for something and removing it introduces bugs

### Applicable Issues

Part of https://github.com/atom/atom-keymap/issues/222

/cc: @ungb Can you help me test this on all platforms using this table https://github.com/atom/atom/issues/12980#issuecomment-253749616