### PR TITLE
Fix so AltGraph is resolved as a modifier and not as a key

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,8 +1,8 @@
 {calculateSpecificity} = require 'clear-cut'
 KeyboardLayout = require 'keyboard-layout'
 
-MODIFIERS = new Set(['ctrl', 'alt', 'shift', 'cmd'])
-ENDS_IN_MODIFIER_REGEX = /(ctrl|alt|shift|cmd)$/
+MODIFIERS = new Set(['ctrl', 'alt', 'shift', 'cmd', 'altgraph'])
+ENDS_IN_MODIFIER_REGEX = /(ctrl|alt|shift|cmd|altgraph)$/
 WHITESPACE_REGEX = /\s+/
 KEY_NAMES_BY_KEYBOARD_EVENT_CODE = {
   'Space': 'space',
@@ -240,6 +240,10 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
     keystroke += 'ctrl'
 
   if key is 'alt' or (altKey and event.type isnt 'keyup')
+    keystroke += '-' if keystroke.length > 0
+    keystroke += 'alt'
+
+  if key is 'altgraph' and process.platform isnt 'darwin' and event.type is 'keyup'
     keystroke += '-' if keystroke.length > 0
     keystroke += 'alt'
 


### PR DESCRIPTION
### Description of the Change

In Atom 1.24 pressing AltGraph on Windows sends these two events:

```
KeyboardEvent {
  isTrusted: true,
  key: "Control",
  code: "ControlLeft",
  location: 1,
  ctrlKey: true
  ...
}

KeyboardEvent {
  isTrusted: true,
  key: "Alt",
  code: "AltRight",
  location: 2,
  ctrlKey: true
  ...
}
```

This changed in Atom 1.25 due to the Electron upgrade so the `Alt` key is now `AltGraph`:

```
KeyboardEvent {
  isTrusted: true,
  key: "Control",
  code: "ControlLeft",
  location: 1,
  ctrlKey: true
  ...
  }

KeyboardEvent {
  isTrusted: true,
  key: "AltGraph",
  code: "AltRight",
  location: 2,
  ctrlKey: true
  ...
  }
```

This caused atom-keymap to resolve a single AltGraph as `ctrl-alt-altgraph` because we receive one event for `Control` which has `altKey` and `ctrlKey` true and one event for `AltGraph` (which also has `altKey` and `ctrlKey` true). Since `AltGraph` is not a [modifier](https://github.com/atom/atom-keymap/blob/802745d4a2a7740d95c5e3f08e141d15fd349457/src/helpers.coffee#L4-L5) Atom resolved this as a key in the following code:

https://github.com/atom/atom-keymap/blob/802745d4a2a7740d95c5e3f08e141d15fd349457/src/helpers.coffee#L254-L256

This also causes issues with partial matching because the AltGraph key cancels pending keystrokes. So a keybinding like:

```
'atom-text-editor:not([mini])':
  'g $': 'editor:move-to-first-character-of-line'
```

Would resolve to `g altgraph` and then `$` never matching the entire keybinding.

This Pull Request adds AltGraph as a modifier and a special case for when the `key` is `altgraph` to correctly resolve when AltGraph is included in the keystroke.

### Alternate Designs

I don't really like the design in this PR but I still went with it! Maybe we can just change the `key` to `alt` when it is `AltGraph` using  `NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY` https://github.com/atom/atom-keymap/blob/802745d4a2a7740d95c5e3f08e141d15fd349457/src/helpers.coffee#L11-L18?

In the interest of time I did not investigate any alternative designs so I could get this PR up and at least document the issue.

There are quite a few issues about AltGraph misbehaving on Linux even before the Electron upgrade so there might be another bug on Linux. If Linux has a similar issue for another reason than this there might be an alternative design that also fixes these issues.

https://github.com/atom/atom/issues/16242
https://github.com/t9md/atom-vim-mode-plus/issues/661
https://github.com/atom/atom-keymap/issues/126
https://github.com/t9md/atom-vim-mode-plus/pull/1031

Happy to hear any ideas for alternatives!

### Benefits

Fixes a regression from the Electron upgrade.

### Possible Drawbacks



### Verification Process

I added the following keymap:
```
'atom-text-editor:not([mini])':
  'g $': 'editor:move-to-first-character-of-line'
```

Since $ is typed using <kbd>AltGraph+4</kbd> on a Swedish layout this command includes the AltGraph character. The expected result is that we can match the keybinding even when AltGraph is included in the keystroke.

I also tested that the command matches if you press `g ctrl-alt-4`.

### Applicable Issues

These are in an earlier version of Atom. There might be some other bug on Linux for AltGraph.

https://github.com/atom/atom/issues/16242
https://github.com/t9md/atom-vim-mode-plus/issues/661
https://github.com/atom/atom-keymap/issues/126
https://github.com/t9md/atom-vim-mode-plus/pull/1031