### PR TITLE
Workaround AltGraph regression on Windows

### DIFF
--- a/spec/keymap-manager-spec.coffee
+++ b/spec/keymap-manager-spec.coffee
@@ -722,6 +722,10 @@ describe "KeymapManager", ->
         currentKeymap = null
         stub(KeyboardLayout, 'getCurrentKeymap', -> currentKeymap)
 
+      it "correctly resolves to AltGraph to ctrl-alt when key is AltGraph on Windows", ->
+        mockProcessPlatform('win32')
+        assert.equal(keymapManager.keystrokeForKeyboardEvent(buildKeydownEvent({key: 'AltGraph', code: 'AltRight', ctrlKey: true, altKey: true})), 'ctrl-alt')
+
       it "allows ASCII characters (<= 127) to be typed via an option modifier on macOS", ->
         mockProcessPlatform('darwin')
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -168,6 +168,8 @@ exports.keystrokeForKeyboardEvent = (event, customKeystrokeResolvers) ->
   isNonCharacterKey = key.length > 1
   if isNonCharacterKey
     key = NON_CHARACTER_KEY_NAMES_BY_KEYBOARD_EVENT_KEY[key] ? key.toLowerCase()
+    if key is "altgraph" and process.platform is "win32"
+      key = "alt"
   else
     # Deal with caps-lock issues. Key bindings should always adjust the
     # capitalization of the key based on the shiftKey state and never the state


### PR DESCRIPTION
### Description of the Change

In Atom 1.24 pressing AltGraph on Windows sends these two events:

```
KeyboardEvent {
  isTrusted: true,
  key: "Control",
  code: "ControlLeft",
  location: 1,
  ctrlKey: true
  ...
}

KeyboardEvent {
  isTrusted: true,
  key: "Alt",
  code: "AltRight",
  location: 2,
  ctrlKey: true
  ...
}
```

This changed in Atom 1.25 due to the Electron upgrade so the `Alt` key is now `AltGraph`:

```
KeyboardEvent {
  isTrusted: true,
  key: "Control",
  code: "ControlLeft",
  location: 1,
  ctrlKey: true
  ...
  }

KeyboardEvent {
  isTrusted: true,
  key: "AltGraph",
  code: "AltRight",
  location: 2,
  ctrlKey: true
  ...
  }
```

This caused atom-keymap to resolve a single AltGraph as `ctrl-alt-altgraph` because we receive one event for `Control` which has `altKey` and `ctrlKey` true and one event for `AltGraph` (which also has `altKey` and `ctrlKey` true). Since `AltGraph` is not a [modifier](https://github.com/atom/atom-keymap/blob/802745d4a2a7740d95c5e3f08e141d15fd349457/src/helpers.coffee#L4-L5) Atom resolved this as a key in the following code:

https://github.com/atom/atom-keymap/blob/802745d4a2a7740d95c5e3f08e141d15fd349457/src/helpers.coffee#L254-L256

This also causes issues with partial matching because the AltGraph key cancels pending keystrokes. So a keybinding like:

```
'atom-text-editor:not([mini])':
  'g $': 'editor:move-to-first-character-of-line'
```

Would resolve to `g altgraph` and then `$` never matching the entire keybinding.

This Pull Request renames AltGraph to Alt on Windows to restore the previous behavior. The same issue exists on Linux but has for a while. A fix for Linux will be addressed in an upcoming PR.

### Benefits

Fixes a regression from the Electron upgrade.

### Verification Process

- [x] **Partial matches should work**

I added the following keymap:
```
'atom-text-editor:not([mini])':
  'g $': 'editor:move-to-first-character-of-line'
```

Since $ is typed using <kbd>AltGraph+4</kbd> on a Swedish layout this command includes the AltGraph character. The expected result is that we can match the keybinding even when AltGraph is included in the keystroke.

I also tested that the command matches if you press `g ctrl-alt-4`.

- [x] **Key up events**

I added the follow to my `init.coffee`:
```coffee
atom.keymaps.addKeystrokeResolver ({keystroke,event}) ->
  if event.type is 'keyup'
    console.log keystroke
```

And checked in the console that I receive keyup events for both `ctrl` and `alt` when releasing AltGraph.

### Applicable Issues

N/A