### PR TITLE
Fix broken arpeggios with meta/ctrl keys

### DIFF
--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -633,7 +633,7 @@ class KeymapManager
     if hasPartialMatches and shouldUsePartialMatches
       enableTimeout = (
         @pendingStateTimeoutHandle? or
-        dispatchedExactMatch? or
+        exactMatchCandidate? or
         characterForKeyboardEvent(@queuedKeyboardEvents[0])?
       )
       enableTimeout = false if replay


### PR DESCRIPTION
### Description of the Change

We noticed that keybindings that partially matched arpeggios behaved pretty strangely. For example:

1. Add a keybinding for `⌘K` (which is a partial match for the "Pane: Split" commands)
2. Type `⌘K`
3. Nothing happens, even after the `partialMatchTimeout`
4. Type another key that rules out the partial matches (including `⌘K` again)
5. It's finally triggered.

If you've given up after step 3, 4 could happen a while later, after you've moved on. What's it doing? Some thing you forgot about 😄

This changes fixes the problem by scheduling the timeout not when an exact match was dispatched (which shouldn't be possible AFAIK), but when an exact match was *found*. I added a test to identify the case, which fails before the commit and passes after.
