### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - libxkbfile-dev
 
 node_js:
-  - "node"
+  - "10"
 
 env:
   - CC=gcc-4.8 CXX=g++-4.8


### PR DESCRIPTION
A recent change I made broke in a way that seems unrelated change. That makes me suspect that the default Travis Node version may have changed since the last build, but not sure.