### PR TITLE
:arrow_up: keyboard-layout@2.0.17 (and rename deprecated "prepublish" script to "prepare")

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4948,9 +4948,9 @@
       }
     },
     "keyboard-layout": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.16.tgz",
-      "integrity": "sha512-eGrxmlV6jbm/mbPEOpYGuH53XEC7wIUj9ZxKcT2z9QHJ/RwrT9iVkvxka9zRxqHZHwQzcffgsa5OxoVAKnhK9w==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.17.tgz",
+      "integrity": "sha512-W9LL+1e8CS9fi0s8ZHINDN1HZ6QpYjE4yLi4+faed7ozppNOAxINjv5w16zG9tJv8Jp5LJrCfO5PZ9aV1m5d4g==",
       "requires": {
         "event-kit": "^2.0.0",
         "nan": "^2.13.2"
@@ -4962,9 +4962,9 @@
           "integrity": "sha512-b7Qi1JNzY4BfAYfnIRanLk0DOD1gdkWHT4GISIn8Q2tAf3LpU8SP2CMwWaq40imYoKWbtN4ZhbSRxvsnikooZQ=="
         },
         "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Atom's DOM-aware keymap module",
   "main": "./lib/keymap-manager",
   "scripts": {
-    "prepublish": "npm run clean && npm run compile && npm run lint && npm run atomdoc",
+    "prepare": "npm run clean && npm run compile && npm run lint && npm run atomdoc",
     "clean": "rimraf lib && rimraf api.json",
     "compile": "coffee --no-header --output lib --compile src && babel src --out-dir lib",
     "lint": "coffeelint -r src spec && eslint src spec",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^3.0.0",
     "grim": "^1.2.1",
-    "keyboard-layout": "2.0.16",
+    "keyboard-layout": "2.0.17",
     "pathwatcher": "^8.0.0",
     "property-accessors": "^1",
     "season": "^6.0.2"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Bump the `keyboard-layout` package to version 2.0.17.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Fix the code warning in the `keyboard-layout` package, I guess.

### Benefits

<!-- What benefits will be realized by the code change? -->

Includes https://github.com/atom/keyboard-layout/pull/59, which allows the module to compile on Windows 32-bit against Electron 10 and newer, by ignoring a compilation warning that would otherwise be treated as a hard error.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None, unless that compilation warning was important. :shrug:

### Applicable Issues

<!-- Enter any applicable Issues here -->

- https://github.com/atom/keyboard-layout/issues/58.
- https://github.com/atom/atom/pull/22687 (Helps Atom build with Electron 11 on Windows 32-bit.)